### PR TITLE
FIX: adapt to string reading in h5py >= 3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
     steps:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2
@@ -70,7 +70,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.7", "3.8", "3.9"]
     steps:
     - uses: actions/checkout@v2
     - uses: conda-incubator/setup-miniconda@v2

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -151,14 +151,8 @@ class BaseVariable(object):
 
     def __getitem__(self, key):
         if getattr(self._root, "decode_strings", False):
-            try:
-                if h5py.check_string_dtype(self._h5ds[key].dtype) is not None:
-                    return self._h5ds.asstr()[key]
-            # need to catch object arrays of bytes (which are returned from
-            # HDF5 variable-length strings)
-            except AttributeError as err:
-                if err.args[0] == "'bytes' object has no attribute 'dtype'":
-                    return self._h5ds.asstr()[key]
+            if h5py.check_string_dtype(self._h5ds.dtype) is not None:
+                return self._h5ds.asstr()[key]
         return self._h5ds[key]
 
     def __setitem__(self, key, value):

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -151,9 +151,14 @@ class BaseVariable(object):
 
     def __getitem__(self, key):
         if getattr(self._root, "decode_strings", False):
-            # need to wrap with np.array to fetch .dtype in any case
-            if h5py.check_string_dtype(np.array(self._h5ds[key]).dtype) is not None:
-                return self._h5ds.asstr()[key]
+            try:
+                if h5py.check_string_dtype(self._h5ds[key].dtype) is not None:
+                    return self._h5ds.asstr()[key]
+            # need to catch object arrays of bytes (which are returned from
+            # HDF5 variable-length strings)
+            except AttributeError as err:
+                if err.args[0] == "'bytes' object has no attribute 'dtype'":
+                    return self._h5ds.asstr()[key]
         return self._h5ds[key]
 
     def __setitem__(self, key, value):

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -752,7 +752,7 @@ class File(Group):
             if "legacy" in self._cls_name:
                 if self.decode_strings is not None:
                     msg = (
-                        "'decode_strings' keyword argument is not allowed in h5netcdf"
+                        "'decode_strings' keyword argument is not allowed in h5netcdf "
                         "legacy API."
                     )
                     raise TypeError(msg)

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -209,9 +209,8 @@ def write_h5netcdf(tmp_netcdf):
     ds.close()
 
 
-def read_legacy_netcdf(tmp_netcdf, read_module, write_module, decode_strings):
-
-    ds = read_module.Dataset(tmp_netcdf, "r", **decode_strings)
+def read_legacy_netcdf(tmp_netcdf, read_module, write_module):
+    ds = read_module.Dataset(tmp_netcdf, "r")
     assert ds.ncattrs() == ["global", "other_attr"]
     assert ds.getncattr("global") == 42
     if write_module is not netCDF4:
@@ -262,16 +261,19 @@ def read_legacy_netcdf(tmp_netcdf, read_module, write_module, decode_strings):
     # Check the behavior if h5py. Cannot expect h5netcdf to overcome these
     # errors:
     if is_h5py_char_working(tmp_netcdf, "z"):
-        ds = read_module.Dataset(tmp_netcdf, "r", **decode_strings)
+        ds = read_module.Dataset(tmp_netcdf, "r")
         v = ds.variables["z"]
-        assert array_equal(v, _char_array)
+        if getattr(ds, "decode_strings", False):
+            assert array_equal(v, np.char.decode(_char_array))
+        else:
+            assert array_equal(v, _char_array)
         assert v.dtype == "S1"
         assert v.ndim == 2
         assert v.dimensions == ("z", "string3")
         assert v.ncattrs() == ["_FillValue"]
         assert v.getncattr("_FillValue") == b"X"
     else:
-        ds = read_module.Dataset(tmp_netcdf, "r", **decode_strings)
+        ds = read_module.Dataset(tmp_netcdf, "r")
 
     v = ds.variables["scalar"]
     assert array_equal(v, np.array(2.0))
@@ -289,7 +291,7 @@ def read_legacy_netcdf(tmp_netcdf, read_module, write_module, decode_strings):
 
     v = ds.variables["var_len_str"]
     assert v.dtype == str
-    assert v[0] == u"foo"
+    assert v[0] == "foo"
 
     v = ds.groups["subgroup"].variables["subvar"]
     assert ds.groups["subgroup"].parent is ds
@@ -357,6 +359,10 @@ def read_h5netcdf(tmp_netcdf, write_module, decode_strings):
     if is_h5py_char_working(tmp_netcdf, "z"):
         ds = h5netcdf.File(tmp_netcdf, "r", **decode_strings)
         v = ds["z"]
+        if getattr(ds, "decode_strings", False):
+            assert array_equal(v, np.char.decode(_char_array))
+        else:
+            assert array_equal(v, _char_array)
         assert v.dtype == "S1"
         assert v.ndim == 2
         assert v.dimensions == ("z", "string3")
@@ -381,10 +387,10 @@ def read_h5netcdf(tmp_netcdf, write_module, decode_strings):
 
     v = ds["var_len_str"]
     assert h5py.check_dtype(vlen=v.dtype) == str
-    foo = b"foo"
-    if decode_strings.get("decode_strings", True):
-        foo = foo.decode()
-    assert v[0] == foo  # "foo"
+    foo = "foo"
+    if not getattr(ds, "decode_strings", True):
+        foo = foo.encode()
+    assert v[0] == foo
 
     v = ds["/subgroup/subvar"]
     assert v is ds["subgroup"]["subvar"]
@@ -405,31 +411,31 @@ def read_h5netcdf(tmp_netcdf, write_module, decode_strings):
     ds.close()
 
 
-def roundtrip_legacy_netcdf(tmp_netcdf, read_module, write_module, decode_strings):
+def roundtrip_legacy_netcdf(tmp_netcdf, read_module, write_module):
     write_legacy_netcdf(tmp_netcdf, write_module)
-    read_legacy_netcdf(tmp_netcdf, read_module, write_module, decode_strings)
+    read_legacy_netcdf(tmp_netcdf, read_module, write_module)
 
 
-def test_write_legacyapi_read_netCDF4(tmp_local_netcdf, decode_strings):
-    roundtrip_legacy_netcdf(tmp_local_netcdf, netCDF4, legacyapi, decode_strings)
+def test_write_legacyapi_read_netCDF4(tmp_local_netcdf):
+    roundtrip_legacy_netcdf(tmp_local_netcdf, netCDF4, legacyapi)
 
 
-def test_roundtrip_h5netcdf_legacyapi(tmp_local_netcdf, decode_strings):
-    roundtrip_legacy_netcdf(tmp_local_netcdf, legacyapi, legacyapi, decode_strings)
+def test_roundtrip_h5netcdf_legacyapi(tmp_local_netcdf):
+    roundtrip_legacy_netcdf(tmp_local_netcdf, legacyapi, legacyapi)
 
 
-def test_write_netCDF4_read_legacyapi(tmp_local_netcdf, decode_strings):
-    roundtrip_legacy_netcdf(tmp_local_netcdf, legacyapi, netCDF4, decode_strings)
+def test_write_netCDF4_read_legacyapi(tmp_local_netcdf):
+    roundtrip_legacy_netcdf(tmp_local_netcdf, legacyapi, netCDF4)
 
 
-def test_write_h5netcdf_read_legacyapi(tmp_local_netcdf, decode_strings):
+def test_write_h5netcdf_read_legacyapi(tmp_local_netcdf):
     write_h5netcdf(tmp_local_netcdf)
-    read_legacy_netcdf(tmp_local_netcdf, legacyapi, h5netcdf, decode_strings)
+    read_legacy_netcdf(tmp_local_netcdf, legacyapi, h5netcdf)
 
 
-def test_write_h5netcdf_read_netCDF4(tmp_local_netcdf, decode_strings):
+def test_write_h5netcdf_read_netCDF4(tmp_local_netcdf):
     write_h5netcdf(tmp_local_netcdf)
-    read_legacy_netcdf(tmp_local_netcdf, netCDF4, h5netcdf, decode_strings)
+    read_legacy_netcdf(tmp_local_netcdf, netCDF4, h5netcdf)
 
 
 def test_roundtrip_h5netcdf(tmp_local_or_remote_netcdf, decode_strings):
@@ -556,6 +562,16 @@ def test_decode_string_warning(tmp_local_or_remote_netcdf):
     write_h5netcdf(tmp_local_or_remote_netcdf)
     with pytest.warns(FutureWarning):
         with h5netcdf.File(tmp_local_or_remote_netcdf, "r") as ds:
+            assert ds.name == "/"
+
+@pytest.mark.skipif(
+    h5py.__version__ < LooseVersion("3.0.0"), reason="not needed with h5py < 3.0"
+)
+def test_decode_string_error(tmp_local_or_remote_netcdf):
+    write_h5netcdf(tmp_local_or_remote_netcdf)
+    with pytest.raises(TypeError):
+        with h5netcdf.legacyapi.Dataset(tmp_local_or_remote_netcdf, "r",
+                                        decode_strings=True) as ds:
             assert ds.name == "/"
 
 

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -564,14 +564,16 @@ def test_decode_string_warning(tmp_local_or_remote_netcdf):
         with h5netcdf.File(tmp_local_or_remote_netcdf, "r") as ds:
             assert ds.name == "/"
 
+
 @pytest.mark.skipif(
     h5py.__version__ < LooseVersion("3.0.0"), reason="not needed with h5py < 3.0"
 )
 def test_decode_string_error(tmp_local_or_remote_netcdf):
     write_h5netcdf(tmp_local_or_remote_netcdf)
     with pytest.raises(TypeError):
-        with h5netcdf.legacyapi.Dataset(tmp_local_or_remote_netcdf, "r",
-                                        decode_strings=True) as ds:
+        with h5netcdf.legacyapi.Dataset(
+            tmp_local_or_remote_netcdf, "r", decode_strings=True
+        ) as ds:
             assert ds.name == "/"
 
 


### PR DESCRIPTION
fixes #81 

How does it work?

- Keeps full backwards compatibility for `h5py` == 2.*

for `h5py` >= 3:

- If `legacy` API -> keeps conformance to netCDF4 (decoding strings by default, raise `TypeError` if `decode_strings` is explicitly set
- If `new` API -> keeps backwards compatibility for the moment (decoding strings by default, emit `FutureWarning` if `decode_strings` is not explicitly set, decoding can be deactivated by setting `decode_strings=False` )
- In future versions conformance with `h5py` >= 3 will be ensured by not decoding strings by default. String decoding can be requested by setting keyword argument `decode_strings=True`.