### PR TITLE
release 0.11.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,14 +1,14 @@
 Change Log
 ----------
 
-Development Version:
+Version 0.11.0 (April 20, 2021):
 
 - Included ``h5pyd.Dataset`` objects as netCDF variables.
   By `Aleksandar Jelenak <https://github.com/ajelenak>`_.
 - Added automatic PyPI upload on creation of github release.
 - Moved Changelog to CHANGELOG.rst.
-- Updated ``decode_vlen_strings`` ``FutureWarning``
-- Support for ``h5py.Empty`` strings
+- Updated ``decode_vlen_strings`` ``FutureWarning``.
+- Support for ``h5py.Empty`` strings.
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 Version 0.10.0 (February 11, 2021):

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -25,7 +25,7 @@ else:
     h5_group_types = (h5py.Group, h5pyd.Group)
     h5_dataset_types = (h5py.Dataset, h5pyd.Dataset)
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 
 
 _NC_PROPERTIES = "version=2,h5netcdf=%s,hdf5=%s,h5py=%s" % (

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     long_description=(
         open("README.rst").read() if os.path.exists("README.rst") else ""
     ),
-    version="0.10.0",
+    version="0.11.0",
     license="BSD",
     classifiers=CLASSIFIERS,
     author="Stephan Hoyer",


### PR DESCRIPTION
At least the support for `h5py.Empty` strings justify a new release. Looking forward to see if the automatic upload works smoothly.

I've added the necessary changes as laid out in the [release workflow description](https://github.com/h5netcdf/h5netcdf/wiki#release-workflow) (first bullet point). The release date in CHANGELOG.rst is set to today. But it would be only minor thing to fix this, if we merge on another day.

@shoyer Please update PR if necessary and merge at your discretion. After merge the github release needs to be created (second bullet point of above release workflow) to finalize the release.


