### PR TITLE
WIP: refactor dimension scales handling

### DIFF
--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -623,11 +623,6 @@ class Group(Mapping):
         self._variables[name] = self._variable_cls(self, name, dimensions)
         variable = self._variables[name]
 
-        # This is a bit of a hack, netCDF4 attaches _Netcdf4Dimid to every variable
-        # in the moment when a variable is first written to, after variable creation.
-        # Here we just attach it to every variable on creation.
-        variable._ensure_dim_id()
-
         if fillvalue is not None:
             value = variable.dtype.type(fillvalue)
             variable.attrs._h5attrs["_FillValue"] = value
@@ -659,6 +654,11 @@ class Group(Mapping):
         variable = self._create_h5netcdf_variable(
             name, dimensions, dtype, data, fillvalue, **kwargs
         )
+
+        # This is a bit of a hack, netCDF4 attaches _Netcdf4Dimid to every variable
+        # in the moment when a variable is first written to, after variable creation.
+        # Here we just attach it to every variable on creation.
+        variable._ensure_dim_id()
 
         if _check_coord_var(self, name, dimensions):
             self._create_dim_scale(name)

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -906,7 +906,7 @@ class File(Group):
             self._closed = False
 
         self._mode = mode
-        self._writable = not (mode == "r")
+        self._writable = mode != "r"
         self._root = self
         self._h5path = "/"
         self.invalid_netcdf = invalid_netcdf

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -737,10 +737,10 @@ class Group(Mapping):
             coord_ids = np.array([dim_order[d] for d in dims], "int32")
             h5ds.attrs["_Netcdf4Coordinates"] = coord_ids
 
-        dimlen = bytes(f"{self._current_dim_sizes[dim]:10}", "ascii")
-        scale_name = dim if dim in self.variables else NOT_A_VARIABLE + dimlen
         # don't re-create scales if they already exist.
         if not h5py.h5ds.is_scale(h5ds.id):
+            dimlen = bytes(f"{self._current_dim_sizes[dim]:10}", "ascii")
+            scale_name = dim if dim in self.variables else NOT_A_VARIABLE + dimlen
             if h5py.__version__ < LooseVersion("2.10.0"):
                 h5ds.dims.create_scale(h5ds, scale_name)
             else:

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -146,7 +146,7 @@ def _check_var_with_coords(grp, name, dimensions):
     name_in_dims = name in grp.dimensions
     name_in_var_dims = name in dimensions
     return (
-        (not name_in_dims and name_in_var_dims)
+        (not name_in_dims and not name_in_var_dims)
         or (name_in_dims and name_in_var_dims and len(dimensions) > 1)
     ) and (not _check_coord_var(grp, name, dimensions))
 

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -89,7 +89,8 @@ class BaseVariable(object):
 
     @property
     def name(self):
-        return self._h5ds.name
+        # fix name if _nc4_non_coord_
+        return self._h5ds.name.replace("_nc4_non_coord_", "")
 
     def _lookup_dimensions(self):
         attrs = self._h5ds.attrs
@@ -220,12 +221,16 @@ class _LazyObjectLookup(Mapping):
 
     def __iter__(self):
         for name in self._objects:
-            yield name
+            # fix variable name for variable which clashes with dim name
+            yield name.replace("_nc4_non_coord_", "")
 
     def __len__(self):
         return len(self._objects)
 
     def __getitem__(self, key):
+        # check for _nc4_non_coord_ variable
+        if key not in self._objects and "_nc4_non_coord_" + key in self._objects:
+            key = "_nc4_non_coord_" + key
         if self._objects[key] is not None:
             return self._objects[key]
         else:
@@ -324,10 +329,7 @@ class Group(Mapping):
 
                 if not _netcdf_dimension_but_not_variable(v):
                     if isinstance(v, h5_dataset_types):
-                        var_name = k
-                        if k.startswith("_nc4_non_coord_"):
-                            var_name = k[len("_nc4_non_coord_") :]
-                        self._variables.add(var_name)
+                        self._variables.add(k)
 
         # iterate over found phony dimensions and create them
         if self._root._phony_dims_mode is not None:

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -404,8 +404,6 @@ class Group(Mapping):
         self._variables = _LazyObjectLookup(self, self._variable_cls)
         self._groups = _LazyObjectLookup(self, self._group_cls)
 
-        self._data_written = False
-
         # # initialize phony dimension counter
         if self._root._phony_dims_mode is not None:
             self._phony_dims = {}

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -207,12 +207,19 @@ class BaseVariable(object):
         return tuple(dims)
 
     def _attach_dim_scales(self):
-        """Attach dimension scales"""
+        """Attach dimension scales for all dimensions"""
         if self._root._writable:
-            for n, dim in enumerate(self.dimensions):
-                self._h5ds.dims[n].attach_scale(self._parent._all_h5groups[dim])
+            for dim in self.dimensions:
+                self._attach_dim_scale(dim)
+
+    def _attach_dim_scale(self, dim):
+        """Attach dimension scales for dimension `dim`"""
+        if self._root._writable:
+            n = self.dimensions.index(dim)
+            self._h5ds.dims[n].attach_scale(self._parent._all_h5groups[dim])
 
     def _attach_coords(self):
+        """Attach _Netcdf4Coordinates attribute"""
         dims = self.dimensions
         coord_ids = np.array([self._parent._dim_order[d] for d in dims], "int32")
         if len(coord_ids) > 1:

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1082,7 +1082,7 @@ def test_resize_dimensions(tmp_local_netcdf):
         f.resize_dimension("x", 3, resize_vars=False)
 
         # This will only resize the dimension, but variables keep untouched.
-        assert f.dimensions["x"] == None
+        assert f.dimensions["x"] is None
         assert f._current_dim_sizes["x"] == 3
         assert f.variables["dummy"].shape == (0, 2)
         assert f.variables["dummy"]._h5ds.maxshape == (None, 2)

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -765,7 +765,10 @@ def test_Netcdf4Dimid(tmp_local_netcdf):
 
     with h5py.File(tmp_local_netcdf, "r") as f:
         # all dimension IDs should be present exactly once
-        dim_ids = {f[name].attrs["_Netcdf4Dimid"] for name in ["x", "foo/x", "foo/y", "x1", "foo/x1", "foo/y1"]}
+        dim_ids = {
+            f[name].attrs["_Netcdf4Dimid"]
+            for name in ["x", "foo/x", "foo/y", "x1", "foo/x1", "foo/y1"]
+        }
         assert dim_ids == {0, 1, 2, 3, 4, 5}
 
 

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1012,6 +1012,43 @@ def test_variable_attach_dim_scales(tmp_local_or_remote_netcdf):
         assert f["dummy"]._h5ds.attrs.get("DIMENSION_LIST", None)[1].any() is False
 
 
+def test_group_dimension_scales(tmp_local_or_remote_netcdf):
+    with h5netcdf.File(tmp_local_or_remote_netcdf, "w") as f:
+        # create dimensions (and dimension scales)
+        f.dimensions["x"] = None
+        f.dimensions["y"] = 15
+
+        assert f._h5group["x"].attrs.get("CLASS", None) == b"DIMENSION_SCALE"
+        assert f._h5group["x"].attrs.get("NAME", None) == NOT_A_VARIABLE + bytes(f"{0:10}", "ascii")
+
+        assert f._h5group["y"].attrs.get("CLASS", None) == b"DIMENSION_SCALE"
+        assert f._h5group["y"].attrs.get("NAME", None) == NOT_A_VARIABLE + bytes(f"{15:10}", "ascii")
+
+        # delete x-scale (completely remove hdf5 dataset)
+        f._delete_dim_scale("x")
+
+        assert "x" not in f._h5group
+        assert f._h5group["y"].attrs.get("CLASS", None) == b"DIMENSION_SCALE"
+        assert f._h5group["y"].attrs.get("NAME", None) == NOT_A_VARIABLE + bytes(f"{15:10}", "ascii")
+
+        # delete y-scale (completely remove hdf5 dataset)
+        f._delete_dim_scale("y")
+
+        assert "x" not in f._h5group
+        assert "y" not in f._h5group
+
+        # re-create dimension and scales
+        f._create_dim_scale("x")
+        f._create_dim_scale("y")
+        assert f._h5group["x"].attrs.get("CLASS", None) == b"DIMENSION_SCALE"
+        assert f._h5group["x"].attrs.get("NAME", None) == NOT_A_VARIABLE + bytes(
+            f"{0:10}", "ascii")
+
+        assert f._h5group["y"].attrs.get("CLASS", None) == b"DIMENSION_SCALE"
+        assert f._h5group["y"].attrs.get("NAME", None) == NOT_A_VARIABLE + bytes(
+            f"{15:10}", "ascii")
+
+
 def test_creating_and_resizing_unlimited_dimensions(tmp_local_or_remote_netcdf):
     with h5netcdf.File(tmp_local_or_remote_netcdf, "w") as f:
         f.dimensions["x"] = None

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1019,17 +1019,23 @@ def test_group_dimension_scales(tmp_local_or_remote_netcdf):
         f.dimensions["y"] = 15
 
         assert f._h5group["x"].attrs.get("CLASS", None) == b"DIMENSION_SCALE"
-        assert f._h5group["x"].attrs.get("NAME", None) == NOT_A_VARIABLE + bytes(f"{0:10}", "ascii")
+        assert f._h5group["x"].attrs.get("NAME", None) == NOT_A_VARIABLE + bytes(
+            f"{0:10}", "ascii"
+        )
 
         assert f._h5group["y"].attrs.get("CLASS", None) == b"DIMENSION_SCALE"
-        assert f._h5group["y"].attrs.get("NAME", None) == NOT_A_VARIABLE + bytes(f"{15:10}", "ascii")
+        assert f._h5group["y"].attrs.get("NAME", None) == NOT_A_VARIABLE + bytes(
+            f"{15:10}", "ascii"
+        )
 
         # delete x-scale (completely remove hdf5 dataset)
         f._delete_dim_scale("x")
 
         assert "x" not in f._h5group
         assert f._h5group["y"].attrs.get("CLASS", None) == b"DIMENSION_SCALE"
-        assert f._h5group["y"].attrs.get("NAME", None) == NOT_A_VARIABLE + bytes(f"{15:10}", "ascii")
+        assert f._h5group["y"].attrs.get("NAME", None) == NOT_A_VARIABLE + bytes(
+            f"{15:10}", "ascii"
+        )
 
         # delete y-scale (completely remove hdf5 dataset)
         f._delete_dim_scale("y")
@@ -1042,11 +1048,13 @@ def test_group_dimension_scales(tmp_local_or_remote_netcdf):
         f._create_dim_scale("y")
         assert f._h5group["x"].attrs.get("CLASS", None) == b"DIMENSION_SCALE"
         assert f._h5group["x"].attrs.get("NAME", None) == NOT_A_VARIABLE + bytes(
-            f"{0:10}", "ascii")
+            f"{0:10}", "ascii"
+        )
 
         assert f._h5group["y"].attrs.get("CLASS", None) == b"DIMENSION_SCALE"
         assert f._h5group["y"].attrs.get("NAME", None) == NOT_A_VARIABLE + bytes(
-            f"{15:10}", "ascii")
+            f"{15:10}", "ascii"
+        )
 
 
 def test_creating_and_resizing_unlimited_dimensions(tmp_local_or_remote_netcdf):

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -923,6 +923,35 @@ def test_invalid_then_valid_no_ncproperties(tmp_local_or_remote_netcdf):
         assert "_NCProperties" not in f.attrs
 
 
+def test_variable_attach_coords(tmp_local_or_remote_netcdf):
+    with h5netcdf.File(tmp_local_or_remote_netcdf, "w") as f:
+        f.dimensions["x"] = None
+        f.dimensions["y"] = 15
+        # create variable
+        f._create_h5netcdf_variable("dummy", dimensions=("x", "y"), dtype=np.int64,
+                                    data=None, fillvalue=None)
+        assert f["dummy"]._h5ds.attrs.get("_Netcdf4Coordinates", None) is None
+
+        # attach coordinates
+        f["dummy"]._attach_coords()
+        assert array_equal(f["dummy"]._h5ds.attrs.get("_Netcdf4Coordinates", None),
+                           np.array([0, 1]))
+
+
+def test_ensure_dim_id(tmp_local_or_remote_netcdf):
+    with h5netcdf.File(tmp_local_or_remote_netcdf, "w") as f:
+        f.dimensions["x"] = None
+        f.dimensions["y"] = 15
+        # create variable
+        f._create_h5netcdf_variable("dummy", dimensions=("x", "y"), dtype=np.int64,
+                                    data=None, fillvalue=None)
+        assert f["dummy"]._h5ds.attrs.get("_Netcdf4Dimid", None) is None
+
+        # add dimid
+        f["dummy"]._ensure_dim_id()
+        assert f["dummy"]._h5ds.attrs.get("_Netcdf4Dimid", None) == 0
+
+
 def test_variable_attach_dim_scales(tmp_local_or_remote_netcdf):
     with h5netcdf.File(tmp_local_or_remote_netcdf, "w") as f:
         f.dimensions["x"] = None

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -923,6 +923,23 @@ def test_invalid_then_valid_no_ncproperties(tmp_local_or_remote_netcdf):
         assert "_NCProperties" not in f.attrs
 
 
+def test_nc4_non_coord(tmp_local_or_remote_netcdf):
+    with h5netcdf.File(tmp_local_or_remote_netcdf, "w") as f:
+        f.dimensions["x"] = None
+        f.dimensions["y"] = 15
+        # create variable
+        f._create_h5netcdf_variable("_nc4_non_coord_x", dimensions=("y"), dtype=np.int64,
+                                    data=None, fillvalue=None)
+        print(f["x"])
+        assert f["x"]
+        assert f["x"].dimensions == "y"
+        assert f["x"]._h5ds.name == "/_nc4_non_coord_x"
+
+    h5 = get_hdf5_module(tmp_local_or_remote_netcdf)
+    with h5.File(tmp_local_or_remote_netcdf, "r") as f:
+        assert f["_nc4_non_coord_x"]
+
+
 def test_variable_attach_coords(tmp_local_or_remote_netcdf):
     with h5netcdf.File(tmp_local_or_remote_netcdf, "w") as f:
         f.dimensions["x"] = None

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -928,8 +928,13 @@ def test_nc4_non_coord(tmp_local_or_remote_netcdf):
         f.dimensions["x"] = None
         f.dimensions["y"] = 15
         # create variable
-        f._create_h5netcdf_variable("_nc4_non_coord_x", dimensions=("y"), dtype=np.int64,
-                                    data=None, fillvalue=None)
+        f._create_h5netcdf_variable(
+            "_nc4_non_coord_x",
+            dimensions=("y"),
+            dtype=np.int64,
+            data=None,
+            fillvalue=None,
+        )
         print(f["x"])
         assert f["x"]
         assert f["x"].dimensions == "y"
@@ -945,14 +950,16 @@ def test_variable_attach_coords(tmp_local_or_remote_netcdf):
         f.dimensions["x"] = None
         f.dimensions["y"] = 15
         # create variable
-        f._create_h5netcdf_variable("dummy", dimensions=("x", "y"), dtype=np.int64,
-                                    data=None, fillvalue=None)
+        f._create_h5netcdf_variable(
+            "dummy", dimensions=("x", "y"), dtype=np.int64, data=None, fillvalue=None
+        )
         assert f["dummy"]._h5ds.attrs.get("_Netcdf4Coordinates", None) is None
 
         # attach coordinates
         f["dummy"]._attach_coords()
-        assert array_equal(f["dummy"]._h5ds.attrs.get("_Netcdf4Coordinates", None),
-                           np.array([0, 1]))
+        assert array_equal(
+            f["dummy"]._h5ds.attrs.get("_Netcdf4Coordinates", None), np.array([0, 1])
+        )
 
 
 def test_ensure_dim_id(tmp_local_or_remote_netcdf):
@@ -960,8 +967,9 @@ def test_ensure_dim_id(tmp_local_or_remote_netcdf):
         f.dimensions["x"] = None
         f.dimensions["y"] = 15
         # create variable
-        f._create_h5netcdf_variable("dummy", dimensions=("x", "y"), dtype=np.int64,
-                                    data=None, fillvalue=None)
+        f._create_h5netcdf_variable(
+            "dummy", dimensions=("x", "y"), dtype=np.int64, data=None, fillvalue=None
+        )
         assert f["dummy"]._h5ds.attrs.get("_Netcdf4Dimid", None) is None
 
         # add dimid
@@ -974,8 +982,9 @@ def test_variable_attach_dim_scales(tmp_local_or_remote_netcdf):
         f.dimensions["x"] = None
         f.dimensions["y"] = 15
         # create variable
-        f._create_h5netcdf_variable("dummy", dimensions=("x", "y"), dtype=np.int64,
-                                    data=None, fillvalue=None)
+        f._create_h5netcdf_variable(
+            "dummy", dimensions=("x", "y"), dtype=np.int64, data=None, fillvalue=None
+        )
         assert f["dummy"]._h5ds.attrs.get("DIMENSION_LIST", None) is None
         # attach dimension scales
         f["dummy"]._attach_dim_scales()
@@ -983,16 +992,16 @@ def test_variable_attach_dim_scales(tmp_local_or_remote_netcdf):
         assert f["dummy"]._h5ds.attrs.get("DIMENSION_LIST", None).shape == (2,)
 
         # detach first scale: results in empty DIMENSION_LIST entry
-        refs = f._get_dim_scale_refs('x')
-        f._detach_dim_scale('x', refs)
+        refs = f._get_dim_scale_refs("x")
+        f._detach_dim_scale("x", refs)
         assert f["dummy"]._h5ds.attrs.get("DIMENSION_LIST", None) is not None
         assert f["dummy"]._h5ds.attrs.get("DIMENSION_LIST", None).shape == (2,)
         assert f["dummy"]._h5ds.attrs.get("DIMENSION_LIST", None)[0].any() is False
         assert f["dummy"]._h5ds.attrs.get("DIMENSION_LIST", None)[1].any()
 
         # detach second scale: results in complete removal of DIMENSION_LIST
-        refs = f._get_dim_scale_refs('y')
-        f._detach_dim_scale('y', refs)
+        refs = f._get_dim_scale_refs("y")
+        f._detach_dim_scale("y", refs)
         print(f["dummy"]._h5ds.attrs.get("DIMENSION_LIST", None))
         assert f["dummy"]._h5ds.attrs.get("DIMENSION_LIST", None) is None
 

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1228,7 +1228,13 @@ def test_resize_dimensions(tmp_local_netcdf):
         # writing to a variable with an unlimited dimension
         # will resize dimension and variable if necessary
         # but will not change any other variables
-        f.variables["dummy"][3:5] = np.ones((2, 2))
+        f.variables["dummy"][3:4] = np.ones((1, 2))
+        assert f.variables["dummy"].shape == (4, 2)
+        assert f.variables["dummy"]._h5ds.maxshape == (None, 2)
+        assert f.variables["dummy3"].shape == (3, 2)
+        assert f.variables["dummy3"]._h5ds.maxshape == (None, 2)
+
+        f.variables["dummy"][4] = np.ones((1, 2))
         assert f._current_dim_sizes["x"] == 5
         assert f.variables["dummy"].shape == (5, 2)
         assert f.variables["dummy"]._h5ds.maxshape == (None, 2)


### PR DESCRIPTION
Fixes #88 

UPDATE: This PR was split into several smaller ones, it will be kept here for reference until completely resolved.

- Dimension scales are now created and attached on the fly, instead of doing the iteration on `flush` over all groups/subgroups.
- When opening a file for writing the maximum dimension id (`_Netcdf4Dimid`) is determined and increased for every newly created dimension (#104)
- Transparent handling of `_nc4_non_coord` (#102)
- Refactored out several functions for dim_scale handling at `h5netcdf.Group` and `h5netcdf.Variable` level
- Automatic resizing of variables and attached unlimited dimensions when writing to variables (#103)
- Adapted `resize_dimension` for both dimension resizing and recursive/non-recursive variable resizing (#103)
- Refactored out `_create_h5netcdf_variable`-function which creates hdf5 dataset and `h5netcdf.Variable` (#105)
- Simplified `_create_child_variable`-function with added checks which (netcdf) variable type will be created (#105) 

Bullet point 2 is now the last bottleneck since we need to iterate over all datasets to get the dimension id. I've used `visititems()` for the iteration.  There is room for further refactoring.

Todo:
- [x] simplifiy variable type checks
- [x] add/update tests for resizing dimensions/variables
- [x] add tests for dimension scale handling (eg. attaching/detaching dimension scales)
- [x] add tests for _nc4_non_coord_ handling
- [x] add/update tests for variable creation
- [ ] add more tests

For performance testing I used the code provided by @aldanor:
```python
import time
import xarray as xr
import numpy as np
import h5py

arr = xr.DataArray(np.random.RandomState(0).randint(-100, 100, (50_000, 3)), dims=['x', 'y'])
ds = xr.Dataset({'arr': arr})

filename = 'test.h5'
save = lambda group: ds.to_netcdf(filename, engine='h5netcdf', mode='a', group=str(group))

with h5py.File(filename, 'w') as _:
    pass

for i in range(250):
    save(i)
```
|  netcdf4    |  h5netcdf 0.11.0  |  h5netcdf-refactor |
|-----|------|-----|
| 15 sec   | 208 sec | 20 sec |

So this is a great improvement, although we do not match `netCDF4`.

Some valuable links on dimension scales:
- https://www.unidata.ucar.edu/blogs/developer/en/entry/dimensions_scales
- https://www.unidata.ucar.edu/blogs/developer/en/entry/dimension_scale2
- https://www.unidata.ucar.edu/blogs/developer/en/entry/dimension_scales_part_3
- https://www.unidata.ucar.edu/blogs/developer/en/entry/netcdf4_shared_dimensions
- https://www.unidata.ucar.edu/blogs/developer/en/entry/netcdf4_use_of_dimension_scales
- https://www.researchgate.net/publication/330347054_2A5_NETCDF-4_PERFORMANCE_IMPROVEMENTS_OPENING_COMPLEX_DATA_FILES

String `NULLTERM` vs `NULLPAD`:
- https://github.com/PyTables/PyTables/issues/264

Testing Notebook:
- https://gist.github.com/kmuehlbauer/99ad4749c4e5923b1364187c6363930a

netcdf4-python quirks:
- `_Netcdf4Dimid` gets attached to all data variables if a 2D coordinate variable is created  and any variable is written/file is reopened for append, see https://github.com/Unidata/netcdf4-python/issues/1104
- unlimited variable dimensions are reported as current size of the dimension scale, even if the variable's underlying `DATASPACE` dimension is smaller (eg.0)   