### PR TITLE
assign dimensions on creation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ----------
 
+Development Version:
+
+- Assign dimensions at creation time, instead of at sync/flush (file-close).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+
 Version 0.12.0 (December 20, 2021):
 
 - Added ``FutureWarning`` to use ``mode='r'`` as default when opening files.


### PR DESCRIPTION
This retrieves the `max_dim_id` count on start if the file is writable and assigns the dimids on the fly.

Update: This changes the current behaviour of iterating over the groups/datasets at file close to iteration at file start. `dim_order` is assigned on the fly instead at file close.This is needed to create/attach and detach/delete dimension scales on the fly (in follow-up PR). 

needed for #101