### PR TITLE
write _NCProperties when overwriting file (mode="w")

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Development Version:
   By `Ryan Grout <https://github.com/groutr>`_.
 - Moved handling of ``_nc4_non_coord_`` to ``h5netcdf.BaseVariable``.
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- Write ``_NCProperties`` when overwriting existing files.
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 Version 0.11.0 (April 20, 2021):
 

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -726,7 +726,7 @@ class File(Group):
                         self._preexisting_file = False
                     self._h5file = h5pyd.File(path, mode, **kwargs)
                 else:
-                    self._preexisting_file = os.path.exists(path)
+                    self._preexisting_file = os.path.exists(path) and mode != "w"
                     self._h5file = h5py.File(path, mode, **kwargs)
             else:  # file-like object
                 if h5py.__version__ < LooseVersion("2.9.0"):

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1111,3 +1111,29 @@ def test_nc4_non_coord(tmp_local_netcdf):
         assert f.dimensions == {"x": None, "y": 2}
         assert list(f.variables) == ["y", "test"]
         assert list(f._h5group.keys()) == ["_nc4_non_coord_y", "test", "x", "y"]
+
+
+def test_overwrite_existing_file(tmp_local_netcdf):
+    # create file with _NCProperties attribute
+    with netCDF4.Dataset(tmp_local_netcdf, "w") as ds:
+        ds.createDimension("x", 10)
+
+    # check attribute
+    with h5netcdf.File(tmp_local_netcdf, "r") as ds:
+        assert ds.attrs._h5attrs.get("_NCProperties", False)
+
+    # overwrite file with legacyapi
+    with legacyapi.Dataset(tmp_local_netcdf, "w") as ds:
+        ds.createDimension("x", 10)
+
+    # check attribute
+    with h5netcdf.File(tmp_local_netcdf, "r") as ds:
+        assert ds.attrs._h5attrs.get("_NCProperties", False)
+
+    # overwrite file with new api
+    with h5netcdf.File(tmp_local_netcdf, "w") as ds:
+        ds.dimensions["x"] = 10
+
+    # check attribute
+    with h5netcdf.File(tmp_local_netcdf, "r") as ds:
+        assert ds.attrs._h5attrs.get("_NCProperties", False)


### PR DESCRIPTION
This fixes an issue where `_NCProperties` isn't written when overwriting existing files.

- added a test which checks if attribute gets written

closes #111 