### PR TITLE
Create/Attach dimension scales on append (``mode="r+"``)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Development Version:
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - Write ``_NCProperties`` when overwriting existing files.
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- Create/Attach dimension scales on append (``mode="r+"``)
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 Version 0.11.0 (April 20, 2021):
 

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -877,7 +877,7 @@ class File(Group):
             groups.extend(group._groups.values())
 
     def flush(self):
-        if "r" not in self._mode:
+        if self._mode != "r":
             self._set_unassigned_dimension_ids()
             self._create_dim_scales()
             self._attach_dim_scales()

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1137,3 +1137,25 @@ def test_overwrite_existing_file(tmp_local_netcdf):
     # check attribute
     with h5netcdf.File(tmp_local_netcdf, "r") as ds:
         assert ds.attrs._h5attrs.get("_NCProperties", False)
+
+
+def test_scales_on_append(tmp_local_netcdf):
+    # create file with _NCProperties attribute
+    with netCDF4.Dataset(tmp_local_netcdf, "w") as ds:
+        ds.createDimension("x", 10)
+
+    # append file with netCDF4
+    with netCDF4.Dataset(tmp_local_netcdf, "r+") as ds:
+        ds.createVariable("test", "i4", ("x",))
+
+    # check scales
+    with h5netcdf.File(tmp_local_netcdf, "r") as ds:
+        assert ds.variables["test"].attrs._h5attrs.get("DIMENSION_LIST", False)
+
+    # append file with legacyapi
+    with legacyapi.Dataset(tmp_local_netcdf, "r+") as ds:
+        ds.createVariable("test1", "i4", ("x",))
+
+    # check scales
+    with h5netcdf.File(tmp_local_netcdf, "r") as ds:
+        assert ds.variables["test1"].attrs._h5attrs.get("DIMENSION_LIST", False)


### PR DESCRIPTION
This fixes an issue where dimension scales weren't created/attached when appending with ``mode="r+"``.

- added tests to check for scales when appending with `mode="r+"`