### PR TITLE
release v0.12.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Change Log
 ----------
 
-Development Version:
+Version 0.12.0 (December 20, 2021):
 
 - Added ``FutureWarning`` to use ``mode='r'`` as default when opening files.
   By `Ryan Grout <https://github.com/groutr>`_.
@@ -15,6 +15,8 @@ Development Version:
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - Switch warning into error when using invalid netCDF features.
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- Avoid circular references to objects referencing h5py objects.
+  By `Tom Augspurger <https://github.com/TomAugspurger>`_.
 
 Version 0.11.0 (April 20, 2021):
 

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -25,7 +25,7 @@ else:
     h5_group_types = (h5py.Group, h5pyd.Group)
     h5_dataset_types = (h5py.Dataset, h5pyd.Dataset)
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 
 
 _NC_PROPERTIES = "version=2,h5netcdf=%s,hdf5=%s,h5py=%s" % (

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     long_description=(
         open("README.rst").read() if os.path.exists("README.rst") else ""
     ),
-    version="0.11.0",
+    version="0.12.0",
     license="BSD",
     classifiers=CLASSIFIERS,
     author="Stephan Hoyer",


### PR DESCRIPTION
Referring to [this comment](https://github.com/h5netcdf/h5netcdf/pull/118#issuecomment-997421682) from @TomAugspurger a new version needs to be released:

Quoting from the comment:

> but getting a release out with #117 would be very helpful for projects like pangeo-forge.

#117 fixed a circular reference issue with ``h5py`` objects.

With this release other changes like:

- moving to default opening with `mode="r"` 
- minor changes in dimension scale handling
- error when using invalid netCDF features

are introduced.

