### PR TITLE
Fixed one more cycle

### DIFF
--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -376,11 +376,6 @@ class Group(Mapping):
         if self.dimensions[dim_name] is not None:
             return max_size
 
-        def _find_dim(h5group, dim):
-            if dim not in h5group:
-                return _find_dim(h5group.parent, dim)
-            return h5group[dim]
-
         dim_variable = _find_dim(self._h5group, dim_name)
 
         if "REFERENCE_LIST" not in dim_variable.attrs:
@@ -928,3 +923,11 @@ class File(Group):
             self.mode,
         )
         return "\n".join([header] + self._repr_body())
+
+
+def _find_dim(h5group, dim):
+    if dim not in h5group:
+        return _find_dim(h5group.parent, dim)
+    return h5group[dim]
+
+

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1189,6 +1189,8 @@ def test_detach_scale(tmp_local_netcdf):
 
 def test_no_circular_references(tmp_local_netcdf):
     # https://github.com/h5py/h5py/issues/2019
+    # Note: this test won't necessarily find all cycles
+    # (e.g. those created by closures defined within a method)
     with h5netcdf.File(tmp_local_netcdf, "w") as ds:
         ds.dimensions["x"] = 2
         ds.dimensions["y"] = 2


### PR DESCRIPTION
Apologies for missing this in #117, but there was at least one more cycle in h5netcdf that my test case didn't pick up. When used via xarray, this seems to come up.

<img width="558" alt="image" src="https://user-images.githubusercontent.com/1312546/146960102-0ff5a663-63d6-4d59-8b34-0d6542a5bd3f.png">

It's apparently created by a cycle in `_determine_current_dimension_size`, by the closure `find_dim`. I'm not sure exactly what cycle is, and so I'm struggling to write a test to detect it. But in the absence of a test, I'm running a more realistic workload against this branch now that'll hopefully detect any issues. I'll try to come up with a test in the meantime.

Apologies again for pushing for a release before really testing stuff out :/