### PR TITLE
Ensure order is tracked by default

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ Development Version:
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - Create/attach dimension scales on the fly, instead of at sync/flush (file-close).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- Ensure order tracking is true for newly created netcdf4 files as required
+  by the netcdf4 standard. This enables files created by h5netcdf to be
+  appended to by netCDF4 library users. (Closes Issue #128)
+  By: `Mark Harfouche <https://github.com/hmaarrfk>`
 
 
 Version 0.12.0 (December 20, 2021):

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -820,7 +820,7 @@ class File(Group):
         -----
         In h5netcdf version 0.12.0 and earlier, order tracking was disabled in
         HDF5 file. As this is a requirement for the current netCDF4 standard,
-        it has been enabled without deprecation in later versions [1]_.
+        it has been enabled without deprecation as of version 0.13.0 [1]_.
 
         Datasets created with h5netcdf version 0.12.0 that are opened with
         newer versions of h5netcdf will continue to disable order tracker.
@@ -841,7 +841,7 @@ class File(Group):
                 f"track_order, if specified must be set to to True (got {track_order})"
                 "to conform to the netCDF4 file format. Please see "
                 "https://github.com/h5netcdf/h5netcdf/issues/130 "
-                "for more details"
+                "for more details."
             )
 
         # Deprecating mode='a' in favor of mode='r'

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1430,3 +1430,12 @@ def test_track_order_false(tmp_local_netcdf):
 
     with h5netcdf.File(tmp_local_netcdf, "w", track_order=True):
         pass
+
+
+def test_monitor_netcdf4_requirement_for_track_order(tmp_local_netcdf):
+    # https://github.com/h5netcdf/h5netcdf/issues/130
+    with h5py.File(tmp_local_netcdf, "w", track_order=False):
+        pass
+    with pytest.raises(OSError):
+        with netCDF4.Dataset(tmp_local_netcdf, mode="a"):
+            pass


### PR DESCRIPTION
This PR sets the order_tracked property to true by default, but for files that already exists, attempts to leave the property in the way it found them
- [x] Closes Issue https://github.com/h5netcdf/h5netcdf/issues/128
- [x] Tests added
    - [x] Basic file appending
    - [x] Editing a variable that already existed
    - [x] Adding a new variable in netcdf4 and reading it n h5netcdf (and vice versa)
- [x] Changes are documented in `CHANGELOG.rst`
