### PR TITLE
Set track_order=False as default to avoid bug in h5py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Development Version:
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - Allow 1D boolean indexers in legacy API.
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- Revert order tracking by default to avoid a bug in ``h5py`` (Closes Issue
+  #136). By `Mark Harfouche <h55ps://github.com/hmaarrfk>`_.
 
 Version 0.13.0 (January 12, 2022):
 

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -981,16 +981,22 @@ class File(Group):
         # standard
         # https://github.com/Unidata/netcdf-c/issues/2054
         # https://github.com/h5netcdf/h5netcdf/issues/128
-        track_order = kwargs.pop("track_order", True)
+        # 2022/01/20: hmaarrfk
+        # However, it was found that this causes issues with attrs and h5py
+        # https://github.com/h5netcdf/h5netcdf/issues/136
+        # https://github.com/h5py/h5py/issues/1385
+        track_order = kwargs.pop("track_order", False)
 
-        if not track_order:
-            self._closed = True
-            raise ValueError(
-                f"track_order, if specified must be set to to True (got {track_order})"
-                "to conform to the netCDF4 file format. Please see "
-                "https://github.com/h5netcdf/h5netcdf/issues/130 "
-                "for more details."
-            )
+        # When the issues with track_order in h5py are resolved, we
+        # can consider uncommenting the code below
+        # if not track_order:
+        #     self._closed = True
+        #     raise ValueError(
+        #         f"track_order, if specified must be set to to True (got {track_order})"
+        #         "to conform to the netCDF4 file format. Please see "
+        #         "https://github.com/h5netcdf/h5netcdf/issues/130 "
+        #         "for more details."
+        #     )
 
         # Deprecating mode='a' in favor of mode='r'
         # If mode is None default to 'a' and issue a warning


### PR DESCRIPTION
Closes https://github.com/h5netcdf/h5netcdf/issues/136

- [x] Tests added
- [x] Changes are documented in `CHANGELOG.rst`


<details> <summary>An earlier debugging attempt that I resolved</summary>

For the life of me i can't get the test to fail in pytest.

```
!git describe --tags
import h5netcdf

def _track_order(self):
    # TODO: make a suggestion to upstream to create a property
    # for files to get if they track the order
    # As of version 3.6.0 this property did not exist
    from h5py.h5p import CRT_ORDER_INDEXED, CRT_ORDER_TRACKED

    gcpl = self._h5group.id.get_create_plist()
    attr_creation_order = gcpl.get_attr_creation_order()
    order_tracked = bool(attr_creation_order & CRT_ORDER_TRACKED)
    order_indexed = bool(attr_creation_order & CRT_ORDER_INDEXED)
    return order_tracked and order_indexed

with h5netcdf.File("test_temp.nc", "w", track_order=True) as h5file:
    assert _track_order(h5file)
    for i in range(10):
        h5file.attrs[f"key{i}"] = i
```

![image](https://user-images.githubusercontent.com/90008/150352466-35da9a56-ec6e-40d1-abae-c4ab5afd9185.png)

</details>
