### PR TITLE
0.13 branch Revert track_order=True avoiding a bug in h5py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ----------
 
+Version 0.13.1 (Unreleased):
+
+- Revert order tracking by default to avoid a bug in ``h5py`` (Closes Issue
+  #136). By `Mark Harfouche <h55ps://github.com/hmaarrfk>`_.
+
 Version 0.13.0 (January 12, 2022):
 
 - Assign dimensions at creation time, instead of at sync/flush (file-close).

--- a/README.rst
+++ b/README.rst
@@ -219,10 +219,14 @@ In h5netcdf version 0.12.0 and earlier, `order tracking`_ was disabled in
 HDF5 file. As this is a requirement for the current netCDF4 standard,
 it has been enabled without deprecation as of version 0.13.0 [*]_.
 
+However in version 0.13.1 this has been reverted due to a bug in a core
+dependency of h5netcdf, h5py `upstream bug`_.
+
 Datasets created with h5netcdf version 0.12.0 that are opened with
 newer versions of h5netcdf will continue to disable order tracker.
 
 .. _order tracking: https://docs.unidata.ucar.edu/netcdf-c/current/file_format_specifications.html#creation_order
+.. _upstream bug: https://github.com/h5netcdf/h5netcdf/issues/136
 .. [*] https://github.com/h5netcdf/h5netcdf/issues/128
 
 Changelog

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -834,15 +834,22 @@ class File(Group):
         # standard
         # https://github.com/Unidata/netcdf-c/issues/2054
         # https://github.com/h5netcdf/h5netcdf/issues/128
-        track_order = kwargs.pop("track_order", True)
+        # 2022/01/20: hmaarrfk
+        # However, it was found that this causes issues with attrs and h5py
+        # https://github.com/h5netcdf/h5netcdf/issues/136
+        # https://github.com/h5py/h5py/issues/1385
+        track_order = kwargs.pop("track_order", False)
 
-        if not track_order:
-            raise ValueError(
-                f"track_order, if specified must be set to to True (got {track_order})"
-                "to conform to the netCDF4 file format. Please see "
-                "https://github.com/h5netcdf/h5netcdf/issues/130 "
-                "for more details."
-            )
+        # When the issues with track_order in h5py are resolved, we
+        # can consider uncommenting the code below
+        # if not track_order:
+        #     self._closed = True
+        #     raise ValueError(
+        #         f"track_order, if specified must be set to to True (got {track_order})"
+        #         "to conform to the netCDF4 file format. Please see "
+        #         "https://github.com/h5netcdf/h5netcdf/issues/130 "
+        #         "for more details."
+        #     )
 
         # Deprecating mode='a' in favor of mode='r'
         # If mode is None default to 'a' and issue a warning

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1093,8 +1093,8 @@ def test_nc4_non_coord(tmp_local_netcdf):
 
     with h5netcdf.File(tmp_local_netcdf, "r") as f:
         assert f.dimensions == {"x": None, "y": 2}
-        assert list(f.variables) == ["test", "y"]
-        assert list(f._h5group.keys()) == ["x", "y", "test", "_nc4_non_coord_y"]
+        assert list(f.variables) == ["y", "test"]
+        assert list(f._h5group.keys()) == ["_nc4_non_coord_y", "test", "x", "y"]
 
 
 def test_overwrite_existing_file(tmp_local_netcdf):
@@ -1392,7 +1392,8 @@ def test_no_circular_references(tmp_local_netcdf):
     with h5netcdf.File(tmp_local_netcdf, "r") as ds:
         assert len(gc.get_referrers(ds)) == 1
 
-
+# https://github.com/h5netcdf/h5netcdf/issues/136
+@pytest.mark.skip(reason="h5py bug with track_order prevents editing with netCDF4")
 def test_creation_with_h5netcdf_edit_with_netcdf4(tmp_local_netcdf):
     # In version 0.12.0, the wrong file creation attributes were used
     # making netcdf4 unable to open files created by h5netcdf
@@ -1422,6 +1423,8 @@ def test_creation_with_h5netcdf_edit_with_netcdf4(tmp_local_netcdf):
         np.testing.assert_array_equal(variable[...].data, 10)
 
 
+# https://github.com/h5netcdf/h5netcdf/issues/136
+@pytest.mark.skip(reason="h5py bug with track_order")
 def test_track_order_false(tmp_local_netcdf):
     # track_order must be specified as True or not specified at all
     # https://github.com/h5netcdf/h5netcdf/issues/130
@@ -1439,3 +1442,31 @@ def test_monitor_netcdf4_requirement_for_track_order(tmp_local_netcdf):
     with pytest.raises(OSError):
         with netCDF4.Dataset(tmp_local_netcdf, mode="a"):
             pass
+
+
+# This should always work with the default file opening settings
+# https://github.com/h5netcdf/h5netcdf/issues/136#issuecomment-1017457067
+def test_more_than_7_attr_creation(tmp_local_netcdf):
+    with h5netcdf.File(tmp_local_netcdf, "w") as h5file:
+        for i in range(100):
+            h5file.attrs[f"key{i}"] = i
+            h5file.attrs[f"key{i}"] = 0
+
+
+# Add a test that is supposed to fail in relation to issue #136
+# We choose to monitor when h5py will have fixed their issue in our test suite
+# to enhance maintainability
+# https://github.com/h5netcdf/h5netcdf/issues/136#issuecomment-1017457067
+@pytest.mark.parametrize("track_order", [False, True])
+def test_more_than_7_attr_creation_track_order(tmp_local_netcdf, track_order):
+    if track_order:
+        expected_errors = pytest.raises(KeyError)
+    else:
+        # We don't expect any errors. This is effectively a void context manager
+        expected_errors = memoryview(b"")
+
+    with expected_errors:
+        with h5netcdf.File(tmp_local_netcdf, "w", track_order=track_order) as h5file:
+            for i in range(100):
+                h5file.attrs[f"key{i}"] = i
+                h5file.attrs[f"key{i}"] = 0


### PR DESCRIPTION
Review after: https://github.com/h5netcdf/h5netcdf/pull/140

- [ ] Closes Issue #xxxx
- [ ] Tests added
- [ ] Changes are documented in `CHANGELOG.rst`
