### PR TITLE
MNT: use setuptools_scm for versioning, use pyproject.toml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   release:
     types:
       - created

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,7 @@
 include CHANGELOG.rst
 include LICENSE
 recursive-include h5netcdf/tests *.py
+exclude .gitignore
+exclude environment.yml
+exclude MANIFEST.in
+prune .github

--- a/h5netcdf/__init__.py
+++ b/h5netcdf/__init__.py
@@ -5,4 +5,11 @@ h5netcdf
 A Python library for the netCDF4 file-format that directly reads and writes
 HDF5 files via h5py, without using the Unidata netCDF library.
 """
-from .core import CompatibilityError, File, Group, Variable, __version__  # noqa
+try:
+    from _version import version as __version__
+except Exception:
+    # Local copy or not installed with setuptools.
+    # Disable minimum version checks on downstream libraries.
+    __version__ = "999"
+
+from .core import CompatibilityError, File, Group, Variable  # noqa

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -13,6 +13,7 @@ from packaging import version
 from .attrs import Attributes
 from .dimensions import Dimension, Dimensions
 from .utils import Frozen
+from . import __version__
 
 try:
     import h5pyd
@@ -24,9 +25,6 @@ else:
     no_h5pyd = False
     h5_group_types = (h5py.Group, h5pyd.Group)
     h5_dataset_types = (h5py.Dataset, h5pyd.Dataset)
-
-__version__ = "0.13.0"
-
 
 _NC_PROPERTIES = "version=2,h5netcdf=%s,hdf5=%s,h5py=%s" % (
     __version__,

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -10,10 +10,10 @@ import h5py
 import numpy as np
 from packaging import version
 
+from . import __version__
 from .attrs import Attributes
 from .dimensions import Dimension, Dimensions
 from .utils import Frozen
-from . import __version__
 
 try:
     import h5pyd

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,13 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "setuptools_scm[toml]>=6.2",
+    "setuptools_scm_git_archive",
+]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "h5netcdf/_version.py"
+version_scheme = "release-branch-semver"
+fallback_version = "999"

--- a/setup.py
+++ b/setup.py
@@ -27,13 +27,13 @@ setup(
     long_description=(
         open("README.rst").read() if os.path.exists("README.rst") else ""
     ),
-    version="0.13.0",
     license="BSD",
     classifiers=CLASSIFIERS,
     author="Stephan Hoyer",
     author_email="shoyer@gmail.com",
     url="https://github.com/h5netcdf/h5netcdf",
     python_requires=">=3.6",
+    setup_requires=["setuptools_scm"],
     install_requires=["h5py", "packaging"],
     tests_require=["netCDF4", "pytest"],
     packages=find_packages(),


### PR DESCRIPTION
This simplifies the versioning process relying only on the creation of the github release/tag. It helps downstream too to get comparable version numbers when building from git/github.