### PR TITLE
fix array attributes and attributes decoding

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Development Version:
   #136). By `Mark Harfouche <h55ps://github.com/hmaarrfk>`_.
 - Implement Dimension-class.
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- Return items from 0-dim and one-element 1-dim array attributes. Return multi-element
+  attributes as lists. Return string attributes as Python strings decoded from their respective
+  encoding (`utf-8`, `ascii`).
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 Version 0.13.0 (January 12, 2022):
 

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1807,3 +1807,99 @@ def test_dimensions_in_parent_groups():
             assert repr(ds0["group00"]) == repr(ds1["group00"])
             assert repr(ds0["group00"]["test"]) == repr(ds1["group00"]["test"])
             assert repr(ds0["group00"]["x"]) == repr(ds1["group00"]["x"])
+
+
+def test_array_attributes(tmp_local_netcdf):
+    with h5netcdf.File(tmp_local_netcdf, "w") as ds:
+        dt = h5py.string_dtype("utf-8")
+        unicode = "unicodé"
+        ds.attrs["unicode"] = unicode
+        ds.attrs["unicode_0dim"] = np.array(unicode, dtype=dt)
+        ds.attrs["unicode_1dim"] = np.array([unicode], dtype=dt)
+        ds.attrs["unicode_arrary"] = np.array([unicode, "foobár"], dtype=dt)
+        ds.attrs["unicode_list"] = [unicode]
+
+        dt = h5py.string_dtype("ascii")
+        ascii = b"ascii"
+        ds.attrs["ascii"] = ascii
+        ds.attrs["ascii_0dim"] = np.array(ascii, dtype=dt)
+        ds.attrs["ascii_1dim"] = np.array([ascii], dtype=dt)
+        ds.attrs["ascii_array"] = np.array([ascii, "foobar"], dtype=dt)
+        ds.attrs["ascii_list"] = [ascii]
+
+        dt = h5py.string_dtype("utf-8", 10)
+        ds.attrs["unicode_fixed"] = np.array(unicode.encode("utf-8"), dtype=dt)
+        ds.attrs["unicode_fixed_0dim"] = np.array(unicode.encode("utf-8"), dtype=dt)
+        ds.attrs["unicode_fixed_1dim"] = np.array([unicode.encode("utf-8")], dtype=dt)
+        ds.attrs["unicode_fixed_arrary"] = np.array(
+            [unicode.encode("utf-8"), "foobár".encode("utf-8")], dtype=dt
+        )
+
+        dt = h5py.string_dtype("ascii", 10)
+        ds.attrs["ascii_fixed"] = np.array(ascii, dtype=dt)
+        ds.attrs["ascii_fixed_0dim"] = np.array(ascii, dtype=dt)
+        ds.attrs["ascii_fixed_1dim"] = np.array([ascii], dtype=dt)
+        ds.attrs["ascii_fixed_array"] = np.array([ascii, "foobar"], dtype=dt)
+
+        ds.attrs["int"] = 1
+        ds.attrs["intlist"] = [1]
+        ds.attrs["int_array"] = np.arange(10)
+
+    with h5netcdf.File(tmp_local_netcdf, mode="r") as ds:
+        assert ds.attrs["unicode"] == unicode
+        assert ds.attrs["unicode_0dim"] == unicode
+        assert ds.attrs["unicode_1dim"] == unicode
+        assert ds.attrs["unicode_arrary"] == [unicode, "foobár"]
+        assert ds.attrs["unicode_list"] == unicode
+
+        # bytes are retrieved as strings
+        ascii = "ascii"
+        assert ds.attrs["ascii"] == ascii
+        assert ds.attrs["ascii_0dim"] == ascii
+        assert ds.attrs["ascii_1dim"] == ascii
+        assert ds.attrs["ascii_array"] == [ascii, "foobar"]
+        assert ds.attrs["ascii_list"] == ascii
+
+        assert ds.attrs["unicode_fixed"] == unicode
+        assert ds.attrs["unicode_fixed_0dim"] == unicode
+        assert ds.attrs["unicode_fixed_1dim"] == unicode
+        assert ds.attrs["unicode_fixed_arrary"] == [unicode, "foobár"]
+
+        assert ds.attrs["ascii_fixed"] == ascii
+        assert ds.attrs["ascii_fixed_0dim"] == ascii
+        assert ds.attrs["ascii_fixed_1dim"] == ascii
+        assert ds.attrs["ascii_fixed_array"] == [ascii, "foobar"]
+
+        assert ds.attrs["int"] == 1
+        assert ds.attrs["intlist"] == 1
+        np.testing.assert_equal(ds.attrs["int_array"], np.arange(10))
+
+    for nc4api in [legacyapi, netCDF4]:
+        with nc4api.Dataset(tmp_local_netcdf, mode="r") as ds:
+            assert ds.unicode == unicode
+            assert ds.unicode_0dim == unicode
+            assert ds.unicode_1dim == unicode
+            assert ds.unicode_arrary == [unicode, "foobár"]
+            assert ds.unicode_list == unicode
+
+            # bytes are retrieved as strings
+            ascii = "ascii"
+            assert ds.ascii == ascii
+            assert ds.ascii_0dim == ascii
+            assert ds.ascii_1dim == ascii
+            assert ds.ascii_array == [ascii, "foobar"]
+            assert ds.ascii_list == ascii
+
+            assert ds.unicode_fixed == unicode
+            assert ds.unicode_fixed_0dim == unicode
+            assert ds.unicode_fixed_1dim == unicode
+            assert ds.unicode_fixed_arrary == [unicode, "foobár"]
+
+            assert ds.ascii_fixed == ascii
+            assert ds.ascii_fixed_0dim == ascii
+            assert ds.ascii_fixed_1dim == ascii
+            assert ds.ascii_fixed_array == [ascii, "foobar"]
+
+            assert ds.int == 1
+            assert ds.intlist == 1
+            np.testing.assert_equal(ds.int_array, np.arange(10))

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1977,11 +1977,9 @@ def test_array_attributes(tmp_local_netcdf):
         assert ds.bytes_0dim == ascii
         assert ds.bytes_1dim == ascii
         assert ds.bytes_array == [ascii, "foobar"]
-        # writing lists is broken with writing h5py2/reading netCDF4
+        # writing/reading lists is broken with h5py2/netCDF4
         if version.parse(h5py.__version__) >= version.parse("3.0.0"):
             assert ds.bytes_list == ascii
-        else:
-            assert ds.bytes_list == "ascii\x7f"
 
         assert ds.unicode_fixed == unicode
         assert ds.unicode_fixed_0dim == unicode


### PR DESCRIPTION
- items are extracted from 0-dim and single element 1-dim attributes
- multi-element 1-dim attributes are returned as list (like netcdf4-python)
- bytes/string attributes are returned as strings decoded from their respective encoding (ascii/utf-8)

<!-- Feel free to remove check-list items which aren't relevant to your changes -->

- [x] Closes Issue #116
- [x] Tests added
- [x] Changes are documented in `CHANGELOG.rst`
