### PR TITLE
directly return non-string Empty-type attributes as numpy array, add test

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ----------
 
+Version 0.14.1 (March 2nd, 2022):
+
+- Directly return non-string ``Empty``-type attributes as empty numpy-ndarray.
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+
 Version 0.14.0 (February 25, 2022):
 
 - Add ``chunking_heuristic`` keyword and custom heuristic ``chunking_heuristic="h5netcdf"``

--- a/h5netcdf/attrs.py
+++ b/h5netcdf/attrs.py
@@ -31,11 +31,15 @@ class Attributes(MutableMapping):
         # see https://github.com/h5py/h5py/issues/2045
         attr = self._h5attrs.get_id(key)
 
-        # see https://github.com/h5netcdf/h5netcdf/issues/94 for details
+        # handle Empty types
         if isinstance(self._h5attrs[key], h5py.Empty):
+            # see https://github.com/h5netcdf/h5netcdf/issues/94 for details
             string_info = h5py.check_string_dtype(self._h5attrs[key].dtype)
             if string_info and string_info.length == 1:
                 return b""
+            # see https://github.com/h5netcdf/h5netcdf/issues/154 for details
+            else:
+                return np.array([], dtype=attr.dtype)
 
         output = self._h5attrs[key]
 

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1860,6 +1860,8 @@ def test_array_attributes(tmp_local_netcdf):
         ds.attrs["int"] = 1
         ds.attrs["intlist"] = [1]
         ds.attrs["int_array"] = np.arange(10)
+        ds.attrs["empty_list"] = []
+        ds.attrs["empty_array"] = np.array([])
 
     with h5netcdf.File(tmp_local_netcdf, mode="r") as ds:
         assert ds.attrs["unicode"] == unicode
@@ -1909,6 +1911,8 @@ def test_array_attributes(tmp_local_netcdf):
         assert ds.attrs["int"] == 1
         assert ds.attrs["intlist"] == 1
         np.testing.assert_equal(ds.attrs["int_array"], np.arange(10))
+        np.testing.assert_equal(ds.attrs["empty_list"], np.array([]))
+        np.testing.assert_equal(ds.attrs["empty_array"], np.array([]))
 
     with legacyapi.Dataset(tmp_local_netcdf, mode="r") as ds:
         assert ds.unicode == unicode
@@ -1958,6 +1962,8 @@ def test_array_attributes(tmp_local_netcdf):
         assert ds.int == 1
         assert ds.intlist == 1
         np.testing.assert_equal(ds.int_array, np.arange(10))
+        np.testing.assert_equal(ds.attrs["empty_list"], np.array([]))
+        np.testing.assert_equal(ds.attrs["empty_array"], np.array([]))
 
     with netCDF4.Dataset(tmp_local_netcdf, mode="r") as ds:
         assert ds.unicode == unicode
@@ -1999,3 +2005,5 @@ def test_array_attributes(tmp_local_netcdf):
         assert ds.int == 1
         assert ds.intlist == 1
         np.testing.assert_equal(ds.int_array, np.arange(10))
+        np.testing.assert_equal(ds.empty_list, np.array([]))
+        np.testing.assert_equal(ds.empty_array, np.array([]))


### PR DESCRIPTION
<!-- Feel free to remove check-list items which aren't relevant to your changes -->

- [x] Closes Issue #154
- [x] Tests added
- [x] Changes are documented in `CHANGELOG.rst`
