### PR TITLE
REL: 0.15.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,15 +151,15 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
+          pip install build setuptools wheel twine
       - name: Package and Upload
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
         run: |
-          python setup.py sdist bdist_wheel --universal
+          python -m build
           twine upload dist/*


### PR DESCRIPTION
Final changes for release 0.15.0. 

- Use [pypa/build](https://github.com/pypa/build) to create sdist and universal wheel

Note: The 0.15 version line will be the last before h5netcdf 1.0. Major problems should be ruled out within the next 14 days.
