### PR TITLE
remove `_NCProperties` from existing file if writing invalid netcdf features

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,9 @@ Development Version:
 
 - Add HSDS pytest-fixture, make tests work with h5ypd.
   By `Aleksandar Jelenak <https://github.com/ajelenak>`_.
+- Remove `_NCProperties` from existing file if writing invalid netcdf features.
+  Warn users if `.nc` file extension is used writing invalid netcdf features.
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 
 Version 0.15.0 (March 18th, 2022):
 

--- a/README.rst
+++ b/README.rst
@@ -180,6 +180,9 @@ when creating a file:
   ds = h5netcdf.legacyapi.Dataset('mydata.h5', invalid_netcdf=True)
   ...
 
+In such cases the `_NCProperties` attribute will not be saved to the file or be removed
+from an existing file. A warning will be issued if the file has `.nc`-extension.
+
 .. rubric:: Footnotes
 
 .. [#] h5netcdf we will raise ``h5netcdf.CompatibilityError``.


### PR DESCRIPTION
- remove `_NCProperties` from existing file if writing invalid netcdf features
- warn users if `.nc` file extension is used writing invalid netcdf features

<!-- Feel free to remove check-list items which aren't relevant to your changes -->

- [x] Closes Issue #165
- [x] Tests added
- [x] Changes are documented in `CHANGELOG.rst`
