### PR TITLE
Fixup tracking order test for h5py 3.7

### DIFF
--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1600,7 +1600,8 @@ def test_more_than_7_attr_creation(tmp_local_netcdf):
 # https://github.com/h5netcdf/h5netcdf/issues/136#issuecomment-1017457067
 @pytest.mark.parametrize("track_order", [False, True])
 def test_more_than_7_attr_creation_track_order(tmp_local_netcdf, track_order):
-    if track_order:
+    h5py_version = version.parse(h5py.__version__)
+    if track_order and h5py_version < version.parse("3.7.0"):
         expected_errors = pytest.raises(KeyError)
     else:
         # We don't expect any errors. This is effectively a void context manager


### PR DESCRIPTION
I don't necessarily have the time to change the default at this moment, but I think this should help the test suite get fixed.

Lets see: 


- [x] Closes Issue #xxxx
- [x] Tests added
- [x] Changes are documented in `CHANGELOG.rst`


xref: https://github.com/h5netcdf/h5netcdf/issues/143