### PR TITLE
Make track_order True as default if h5py is 3.7.0 or greater

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,8 +12,8 @@ Development Version:
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - Fix regression in padding algorithm, add test.
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
-- Set ``track_order=True`` by default in created files if h5py greater than
-  3.7.0 is detected to help compatibility with netCDF4-c programs.
+- Set ``track_order=True`` by default in created files if h5py 3.7.0 or 
+  greater is detected to help compatibility with netCDF4-c programs.
   By `Mark Harfouche <https://github.com/hmaarrfk>`_.
 
 Version 1.0.2 (August 2nd, 2022):

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ Development Version:
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
 - Fix regression in padding algorithm, add test.
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_.
+- Set ``track_order=True`` by default in created files if h5py greater than
+  3.7.0 is detected to help compatibility with netCDF4-c programs.
+  By `Mark Harfouche <https://github.com/hmaarrfk>`_.
 
 Version 1.0.2 (August 2nd, 2022):
 

--- a/README.rst
+++ b/README.rst
@@ -241,15 +241,30 @@ to group access time. The created phony dimension naming will differ from
 Track Order
 ~~~~~~~~~~~
 
-In h5netcdf version 0.12.0 and earlier, `order tracking`_ was disabled in
-HDF5 file. As this is a requirement for the current netCDF4 standard,
-it has been enabled without deprecation as of version 0.13.0 `[*]`_.
+As of h5netcdf 1.1.0, if h5py 3.7.0 or greater is detected, the ``track_order``
+parameter is set to ``True`` enabling `order tracking`_ for newly created
+netCDF4 files. This helps ensure that files created with the h5netcdf library
+can be modified by the netCDF4-c and netCDF4-python implementation used in
+other software stacks. Since this change should be transparent to most users,
+it was made without deprecation.
 
-However in version 0.13.1 this has been reverted due to a bug in a core
-dependency of h5netcdf, h5py `upstream bug`_.
+Since track_order is set at creation time, any dataset that was created with
+``track_order=False`` (h5netcdf version 1.0.2 and older except for 0.13.0) will
+continue to opened with order tracker disabled.
 
-Datasets created with h5netcdf version 0.12.0 that are opened with
-newer versions of h5netcdf will continue to disable order tracker.
+The following describes the behavior of h5netcdf with respect to order tracking
+for a few key versions:
+
+- Version 0.12.0 and earlier, the ``track_order`` parameter`order was missing
+  and thus order tracking was implicitely set to ``False``.
+- Version 0.13.0 enabled order tracking by setting the parameter
+  ``track_order`` to ``True`` by default without deprecation.
+- Versions 0.13.1 to 1.0.2 set ``track_order`` to ``False`` due to a bug in a
+  core dependency of h5netcdf, h5py `upstream bug`_ which was resolved in h5py
+  3.7.0 with the help of the h5netcdf team.
+- In version 1.1.0, if h5py 3.7.0 or above is detected, the ``track_order``
+  parameter is set to ``True`` by default.
+
 
 .. _order tracking: https://docs.unidata.ucar.edu/netcdf-c/current/file_format_specifications.html#creation_order
 .. _upstream bug: https://github.com/h5netcdf/h5netcdf/issues/136

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -1026,7 +1026,7 @@ class File(Group):
         track_order_default = version.parse(h5py.__version__) >= version.parse("3.7.0")
         track_order = kwargs.pop("track_order", track_order_default)
 
-        if h5py_version_parsed >= version.parse("3.0.0"):
+        if version.parse(h5py.__version__) >= version.parse("3.0.0"):
             self.decode_vlen_strings = kwargs.pop("decode_vlen_strings", None)
         try:
             if isinstance(path, str):

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1664,18 +1664,6 @@ def test_more_than_7_attr_creation_track_order(tmp_local_netcdf, track_order):
                 h5file.attrs[f"key{i}"] = 0
 
 
-# Add a test that is supposed to fail in relation to issue #136
-# We choose to monitor when h5py will have fixed their issue in our test suite
-# to enhance maintainability
-# https://github.com/h5netcdf/h5netcdf/issues/136#issuecomment-1017457067
-@pytest.mark.parametrize("track_order", [False, True])
-def test_more_than_7_attr_creation_track_order(tmp_local_netcdf, track_order):
-    with h5netcdf.File(tmp_local_netcdf, "w", track_order=track_order) as h5file:
-        for i in range(100):
-            h5file.attrs[f"key{i}"] = i
-            h5file.attrs[f"key{i}"] = 0
-
-
 def test_group_names(tmp_local_netcdf):
     # https://github.com/h5netcdf/h5netcdf/issues/68
     with netCDF4.Dataset(tmp_local_netcdf, mode="w") as ds:

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1189,6 +1189,7 @@ def test_track_order_for_variable_creation(tmp_local_netcdf):
         assert f.dimensions["y"].size == 2
         if version.parse(h5py.__version__) >= version.parse("3.7.0"):
             assert list(f.variables) == ["test", "y"]
+            assert list(f._h5group.keys()) == [ "x", "y", "test", "_nc4_non_coord_y"]
 
     with h5netcdf.File(tmp_local_netcdf, "w") as f:
         f.dimensions = {"x": None, "y": 2}
@@ -1202,6 +1203,7 @@ def test_track_order_for_variable_creation(tmp_local_netcdf):
         assert f.dimensions["y"].size == 2
         if version.parse(h5py.__version__) >= version.parse("3.7.0"):
             assert list(f.variables) == ["y", "test"]
+            assert list(f._h5group.keys()) == [ "x", "y", "_nc4_non_coord_y", "test"]
 
 
 def test_overwrite_existing_file(tmp_local_netcdf):

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1638,6 +1638,18 @@ def test_track_order_specification(tmp_local_netcdf):
 # This should always work with the default file opening settings
 # https://github.com/h5netcdf/h5netcdf/issues/136#issuecomment-1017457067
 def test_more_than_7_attr_creation(tmp_local_netcdf):
+   with h5netcdf.File(tmp_local_netcdf, "w") as h5file:
+        for i in range(100):
+            h5file.attrs[f"key{i}"] = i
+            h5file.attrs[f"key{i}"] = 0
+
+
+# Add a test that is supposed to fail in relation to issue #136
+# We choose to monitor when h5py will have fixed their issue in our test suite
+# to enhance maintainability
+# https://github.com/h5netcdf/h5netcdf/issues/136#issuecomment-1017457067
+@pytest.mark.parametrize("track_order", [False, True])
+def test_more_than_7_attr_creation_track_order(tmp_local_netcdf, track_order):
     h5py_version = version.parse(h5py.__version__)
     if track_order and h5py_version < version.parse("3.7.0"):
         expected_errors = pytest.raises(KeyError)

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1645,15 +1645,11 @@ def test_more_than_7_attr_creation(tmp_local_netcdf):
         # We don't expect any errors. This is effectively a void context manager
         expected_errors = memoryview(b"")
 
-    with expected_errors:
-        with h5netcdf.File(tmp_local_netcdf, "w", track_order=track_order) as h5file:
+    with h5netcdf.File(tmp_local_netcdf, "w", track_order=track_order) as h5file:
+        with expected_errors:
             for i in range(100):
                 h5file.attrs[f"key{i}"] = i
                 h5file.attrs[f"key{i}"] = 0
-    with h5netcdf.File(tmp_local_netcdf, "w", track_order=track_order) as h5file:
-        for i in range(100):
-            h5file.attrs[f"key{i}"] = i
-            h5file.attrs[f"key{i}"] = 0
 
 
 # Add a test that is supposed to fail in relation to issue #136

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1176,7 +1176,13 @@ def test_reading_special_datatype_created_with_c_api(tmp_local_netcdf):
         pass
 
 
-def test_track_order_for_variable_creation(tmp_local_netcdf):
+def test_nc4_non_coord(tmp_local_netcdf):
+    # Here we generate a few variables and coordinates
+    # The default should be to track the order of creation
+    # Thus, on reopening the file, the order in which
+    # the variables are listed should be maintained
+    # y   --   refers to the coordinate y
+    # _nc4_non_coord_y  --  refers to the data y
     with h5netcdf.File(tmp_local_netcdf, "w") as f:
         f.dimensions = {"x": None, "y": 2}
         f.create_variable("test", dimensions=("x",), dtype=np.int64)
@@ -1189,7 +1195,7 @@ def test_track_order_for_variable_creation(tmp_local_netcdf):
         assert f.dimensions["y"].size == 2
         if version.parse(h5py.__version__) >= version.parse("3.7.0"):
             assert list(f.variables) == ["test", "y"]
-            assert list(f._h5group.keys()) == [ "x", "y", "test", "_nc4_non_coord_y"]
+            assert list(f._h5group.keys()) == ["x", "y", "test", "_nc4_non_coord_y"]
 
     with h5netcdf.File(tmp_local_netcdf, "w") as f:
         f.dimensions = {"x": None, "y": 2}
@@ -1203,7 +1209,7 @@ def test_track_order_for_variable_creation(tmp_local_netcdf):
         assert f.dimensions["y"].size == 2
         if version.parse(h5py.__version__) >= version.parse("3.7.0"):
             assert list(f.variables) == ["y", "test"]
-            assert list(f._h5group.keys()) == [ "x", "y", "_nc4_non_coord_y", "test"]
+            assert list(f._h5group.keys()) == ["x", "y", "_nc4_non_coord_y", "test"]
 
 
 def test_overwrite_existing_file(tmp_local_netcdf):

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1638,7 +1638,7 @@ def test_track_order_specification(tmp_local_netcdf):
 # This should always work with the default file opening settings
 # https://github.com/h5netcdf/h5netcdf/issues/136#issuecomment-1017457067
 def test_more_than_7_attr_creation(tmp_local_netcdf):
-   with h5netcdf.File(tmp_local_netcdf, "w") as h5file:
+    with h5netcdf.File(tmp_local_netcdf, "w") as h5file:
         for i in range(100):
             h5file.attrs[f"key{i}"] = i
             h5file.attrs[f"key{i}"] = 0

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -1638,7 +1638,19 @@ def test_track_order_specification(tmp_local_netcdf):
 # This should always work with the default file opening settings
 # https://github.com/h5netcdf/h5netcdf/issues/136#issuecomment-1017457067
 def test_more_than_7_attr_creation(tmp_local_netcdf):
-    with h5netcdf.File(tmp_local_netcdf, "w") as h5file:
+    h5py_version = version.parse(h5py.__version__)
+    if track_order and h5py_version < version.parse("3.7.0"):
+        expected_errors = pytest.raises(KeyError)
+    else:
+        # We don't expect any errors. This is effectively a void context manager
+        expected_errors = memoryview(b"")
+
+    with expected_errors:
+        with h5netcdf.File(tmp_local_netcdf, "w", track_order=track_order) as h5file:
+            for i in range(100):
+                h5file.attrs[f"key{i}"] = i
+                h5file.attrs[f"key{i}"] = 0
+    with h5netcdf.File(tmp_local_netcdf, "w", track_order=track_order) as h5file:
         for i in range(100):
             h5file.attrs[f"key{i}"] = i
             h5file.attrs[f"key{i}"] = 0


### PR DESCRIPTION
Closes: https://github.com/h5netcdf/h5netcdf/issues/143


- [x] Tests added
- [x] Changes are documented in `CHANGELOG.rst`
