### PR TITLE
Add h5netcdf/_version.py to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ build
 dist
 __pycache__
 .vscode
+h5netcdf/_version.py


### PR DESCRIPTION
Mostly i want to test the CIs to see if i broke something in https://github.com/h5netcdf/h5netcdf/pull/185

<!-- Feel free to remove check-list items which aren't relevant to your changes -->

- [ ] Closes Issue #xxxx
- [ ] Tests added
- [ ] Changes are documented in `CHANGELOG.rst`
