### PR TITLE
Speed up dataset opening by caching many HDF5 variables

### DIFF
--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -116,14 +116,8 @@ class BaseVariable(object):
         # fix name if _nc4_non_coord_
         self._name = self._h5ds.name.replace("_nc4_non_coord_", "")
 
-
         self._dtype = None
         self._dimensions = dimensions
-        if self._dimensions is not None:
-            all_dimensions = self._parent._all_dimensions
-            self._shape = tuple(all_dimensions[d].size for d in self.dimensions)
-        else:
-            self._shape = None
         self._initialized = True
 
     @property
@@ -276,10 +270,7 @@ class BaseVariable(object):
     def shape(self):
         """Return current sizes of all variable dimensions."""
         # return actual dimensions sizes, this is in line with netcdf4-python
-        if self._shape is None:
-            all_dimensions = self._parent._all_dimensions
-            self._shape = tuple(all_dimensions[d].size for d in self.dimensions)
-        return self._shape
+        return tuple([self._parent._all_dimensions[d].size for d in self.dimensions])
 
     @property
     def ndim(self):

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -7,6 +7,7 @@ from collections import ChainMap, Counter, OrderedDict, defaultdict
 from collections.abc import Mapping
 
 import h5py
+from h5py import h5i, h5r
 import numpy as np
 from packaging import version
 
@@ -114,7 +115,7 @@ class BaseVariable(object):
 
         self._h5ds = self._root._h5file[self._h5path]
         # fix name if _nc4_non_coord_
-        self._name = self._h5ds.name.replace("_nc4_non_coord_", "")
+        self._name = self._h5path.replace("_nc4_non_coord_", "")
 
         self._dtype = None
         self._dimensions = dimensions
@@ -158,8 +159,8 @@ class BaseVariable(object):
                 dimension_list = list(attrs["DIMENSION_LIST"])
                 h5file_id = self._root._h5file.id
                 return tuple(
-                    h5py.h5i.get_name(
-                        h5py.h5r.dereference(ref[-1], h5file_id)
+                    h5i.get_name(
+                        h5r.dereference(ref[-1], h5file_id)
                     ).split(b"/")[-1].decode('utf-8')
                     for ref in dimension_list
                 )
@@ -270,7 +271,7 @@ class BaseVariable(object):
     def shape(self):
         """Return current sizes of all variable dimensions."""
         # return actual dimensions sizes, this is in line with netcdf4-python
-        return tuple([self._parent._all_dimensions[d].size for d in self.dimensions])
+        return tuple(self._parent._all_dimensions[d].size for d in self.dimensions)
 
     @property
     def ndim(self):

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -284,9 +284,7 @@ class BaseVariable(object):
     @property
     def dtype(self):
         """Return NumPy dtype object giving the variable’s type."""
-        if self._dtype is None:
-            self._dtype = self._h5ds.dtype
-        return self._dtype
+        return self._h5ds.dtype
 
     def _get_padding(self, key):
         """Return padding if needed, defaults to False."""

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -166,7 +166,7 @@ class BaseVariable(object):
                 )
 
         # need to use the h5ds name here to distinguish from collision dimensions
-        child_name = self.name.split("/")[-1]
+        child_name = self._h5path.split("/")[-1]
         if child_name in self._parent._all_dimensions:
             return (child_name,)
 

--- a/h5netcdf/dimensions.py
+++ b/h5netcdf/dimensions.py
@@ -86,9 +86,15 @@ class Dimension(object):
             self._root._phony_dim_count += 1
         else:
             self._root._max_dim_id += 1
+
         self._dimensionid = self._root._max_dim_id
-        if parent._root._writable and create_h5ds and not self._phony:
+        if self._phony:
+            self._h5ds = None
+        elif parent._root._writable and create_h5ds:
+            # Create scale will create the self._h5ds object
             self._create_scale()
+        else:
+            self._h5ds = self._root._h5file[self._h5path]
         self._initialized = True
 
     @property
@@ -131,12 +137,6 @@ class Dimension(object):
         if self._phony:
             return False
         return self._h5ds.maxshape == (None,)
-
-    @property
-    def _h5ds(self):
-        if self._phony:
-            return None
-        return self._root._h5file[self._h5path]
 
     @property
     def _isscale(self):
@@ -184,6 +184,8 @@ class Dimension(object):
                 dtype=">f4",
                 **kwargs,
             )
+
+        self._h5ds = self._root._h5file[self._h5path]
         self._h5ds.attrs["_Netcdf4Dimid"] = np.array(self._dimid, dtype=np.int32)
 
         if len(self._h5ds.shape) > 1:

--- a/h5netcdf/dimensions.py
+++ b/h5netcdf/dimensions.py
@@ -86,7 +86,6 @@ class Dimension(object):
             self._root._phony_dim_count += 1
         else:
             self._root._max_dim_id += 1
-
         self._dimensionid = self._root._max_dim_id
         if self._phony:
             self._h5ds = None

--- a/h5netcdf/utils.py
+++ b/h5netcdf/utils.py
@@ -24,3 +24,6 @@ class Frozen(Mapping):
 
     def __repr__(self):
         return "%s(%r)" % (type(self).__name__, self._mapping)
+
+    def items(self):
+        return self._mapping.items()


### PR DESCRIPTION
We are trying to use h5netcdf in our pipeline since it offers alot of flexibility in how HDF5 is accessed and used.

However, we noticed that for some of our datasets, they open with 
* xarray + netcdf4-python in about 80 ms
* xarray + h5netcdf: 600 ms.

I've been working on speeding things up, much of it involces caching results from accesses to the HDF5 file.

There are a few questions I had, so I'm opening up this merge request to give me a place to ask them.

I've narrowed the gap to 240 ms vs 80 ms.  I'll also try to "donate" a dataset. It mostly has 130 data variables, that share many coordinates. Our new datasets really cut down on the coordinates (which I think helps) but given the proliferation of these datasets, even internally, I'm interested in general speedups where I can get them.

As promised, the dataset one can use to benchmark:

The dataset contains `images` (I made them monochrome for easy viewing) which can be viewed.

This is a screenshot from our viewer, but you can likely open them in matplotlib too.
```python
import xarray as xr
import h5netcdf  # pay the cost of lazy loading here so it doesn't appear in the benchmarks
filename = 'sample_file_zebrafish_0.18.55_4uCams_small.nc'
dataset = xr.open_dataset(filename, engine='h5netcdf')
```
```python
# Visualize
from matplotlib import pyplot as plt
# There are 4 images (0, 0), (0, 1), (1, 0), and (1, 1)
plt.imshow(dataset['images'][0, 0], cmap='gray')
```

![image](https://user-images.githubusercontent.com/90008/202945018-5ffa9290-3dde-4544-8e0d-5ecce4c5fe66.png)


[sample_file_zebrafish_0.18.55_4uCams_small.zip](https://github.com/h5netcdf/h5netcdf/files/10051903/sample_file_zebrafish_0.18.55_4uCams_small.zip)

Initial timing on my machine shows that this takes about 
* 250 ms to load with the main branch.
* With this branch, it cuts it down to 125 ms (but at the time of adding the dataset, it has a segfault)
* xarray + netcdf take about 31 ms to load the file.

The benchmark is the following:
```python
import xarray as xr
import h5netcdf  # eagerly import for benchmark
import netCDF4  # eagerly import for benchmark
filename = 'sample_file_zebrafish_0.18.55_4uCams_small.nc'

%%timeit
xr.open_dataset(filename, engine="netcdf4").close()
# %%
%%timeit
xr.open_dataset(filename, engine="h5netcdf").close()
```


- [ ] Closes Issue #xxxx
- [ ] Tests added
- [ ] Changes are documented in `CHANGELOG.rst`
