### PR TITLE
Cache dtype for faster variable access

### DIFF
--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -298,8 +298,9 @@ class BaseVariable(object):
                 # https://github.com/h5netcdf/h5netcdf/pull/125/
                 key = _transform_1d_boolean_indexers(key)
 
+            h5ds = self._h5ds
             if getattr(self._root, "decode_vlen_strings", False):
-                string_info = self._root._h5py.check_string_dtype(self._h5ds.dtype)
+                string_info = self._root._h5py.check_string_dtype(h5ds.dtype)
                 if string_info and string_info.length is None:
                     return self._h5ds.asstr()[key]
 
@@ -307,15 +308,15 @@ class BaseVariable(object):
             padding = _get_padding(h5ds, self.shape, key)
             # apply padding with fillvalue (both api)
             if padding:
-                fv = self.dtype.type(self._h5ds.fillvalue)
+                fv = self.dtype.type(h5ds.fillvalue)
                 return np.pad(
-                    self._h5ds,
+                    h5ds,
                     pad_width=padding,
                     mode="constant",
                     constant_values=fv,
                 )[key]
 
-            return self._h5ds[key]
+            return h5ds[key]
     else:
         def __getitem__(self, key):
             root = self._root


### PR DESCRIPTION
It seems that many aspects try to access the dtype, and this can slow things down when accessing variables.

I've found that this can speed up certain access times of mine by a factor 2. I'll try to recreate it with the file I provided.

... I really wish it was easy to find small files that recreate this issue, I have to admit, the file I'm benchmarking on is about 16GB in size.  In a read only usecase.

Before

```
============= ================
--               filename 
------------- ----------------
    engine      my_file.nc
============= ================
   netcdf4      19.5±0ms      
   h5netcdf     81.2±0ms      
 h5py_direct    13.1±0ms      
============= ================
```

After
```
============= ================
--               filename 
------------- ----------------
    engine      my_file.nc
============= ================
   netcdf4      19.3±0ms      
   h5netcdf     19.9±0ms      
 h5py_direct    13.1±0ms      
============= ================
```

The benchmark looks something like:

```
import xarray as xr
dataset = xr.open_dataset(filename, engine=engine)
variable = dataset.images.variable
for i in range(30):
    variable[i].data
```
<!-- Feel free to remove check-list items which aren't relevant to your changes -->

- [ ] Closes Issue #xxxx
- [ ] Tests added
- [ ] Changes are documented in `CHANGELOG.rst`
