### PR TITLE
support for HDF5 dimension scales with null dataspace

### DIFF
--- a/h5netcdf/dimensions.py
+++ b/h5netcdf/dimensions.py
@@ -116,7 +116,7 @@ class Dimension(object):
             # and is only compatible with netCDF4 if all axes that reference
             # the dimension have the same length
             try:
-                reflist = self._h5ds.attrs.get("REFERENCE_LIST")
+                reflist = self._h5ds.attrs["REFERENCE_LIST"]
             except KeyError:
                 msg = f"Dimension {self.name!r} has no discernable length."
                 raise CompatibilityError(msg)

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -735,7 +735,7 @@ def test_valid_null_dimension_scales(tmp_local_or_remote_netcdf):
     with h5.File(tmp_local_or_remote_netcdf, "w") as f:
         foo = f.create_dataset("foo", shape=(5,), dtype=float)
         x = f.create_dataset("x", shape=None, dtype=int)
-        x.make_scale("x")
+        x.make_scale()
         foo.dims[0].attach_scale(x)
 
     with h5netcdf.File(tmp_local_or_remote_netcdf, "r") as ds:
@@ -749,9 +749,19 @@ def test_invalid_null_dimension_scales(tmp_local_or_remote_netcdf):
         foo1 = f.create_dataset("foo1", shape=(4,), dtype=float)
         foo2 = f.create_dataset("foo2", shape=(5,), dtype=float)
         x = f.create_dataset("x", shape=None, dtype=int)
-        x.make_scale("x")
+        x.make_scale()
         foo1.dims[0].attach_scale(x)
         foo2.dims[0].attach_scale(x)
+
+    with raises(CompatibilityError):
+        with h5netcdf.File(tmp_local_or_remote_netcdf, "r") as ds:
+            assert ds
+            print(ds)
+
+    with h5.File(tmp_local_or_remote_netcdf, "w") as f:
+        f.create_dataset("foo", shape=(4,), dtype=float)
+        x = f.create_dataset("x", shape=None, dtype=int)
+        x.make_scale()
 
     with raises(CompatibilityError):
         with h5netcdf.File(tmp_local_or_remote_netcdf, "r") as ds:

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -730,6 +730,35 @@ def test_invalid_netcdf4_mixed(tmp_local_or_remote_netcdf):
             ds.variables["foo1"].dimensions
 
 
+def test_valid_null_dimension_scales(tmp_local_or_remote_netcdf):
+    h5 = get_hdf5_module(tmp_local_or_remote_netcdf)
+    with h5.File(tmp_local_or_remote_netcdf, "w") as f:
+        foo = f.create_dataset("foo", shape=(5,), dtype=float)
+        x = f.create_dataset("x", shape=None, dtype=int)
+        x.make_scale("x")
+        foo.dims[0].attach_scale(x)
+
+    with h5netcdf.File(tmp_local_or_remote_netcdf, "r") as ds:
+        assert ds.dimensions["x"].size == 5
+        assert len(ds.variables) == 1
+
+
+def test_invalid_null_dimension_scales(tmp_local_or_remote_netcdf):
+    h5 = get_hdf5_module(tmp_local_or_remote_netcdf)
+    with h5.File(tmp_local_or_remote_netcdf, "w") as f:
+        foo1 = f.create_dataset("foo1", shape=(4,), dtype=float)
+        foo2 = f.create_dataset("foo2", shape=(5,), dtype=float)
+        x = f.create_dataset("x", shape=None, dtype=int)
+        x.make_scale("x")
+        foo1.dims[0].attach_scale(x)
+        foo2.dims[0].attach_scale(x)
+
+    with raises(CompatibilityError):
+        with h5netcdf.File(tmp_local_or_remote_netcdf, "r") as ds:
+            assert ds
+            print(ds)
+
+
 def test_invalid_netcdf_malformed_dimension_scales(tmp_local_or_remote_netcdf):
     h5 = get_hdf5_module(tmp_local_or_remote_netcdf)
     with h5.File(tmp_local_or_remote_netcdf, "w") as f:

--- a/h5netcdf/utils.py
+++ b/h5netcdf/utils.py
@@ -1,6 +1,10 @@
 from collections.abc import Mapping
 
 
+class CompatibilityError(Exception):
+    """Raised when using features that are not part of the NetCDF4 API."""
+
+
 class Frozen(Mapping):
     """Wrapper around an object implementing the mapping interface to make it
     immutable. If you really want to modify the mapping, the mutable version is


### PR DESCRIPTION
- [x] Closes #204
- [x] Tests added
- [ ] Changes are documented in `CHANGELOG.rst`

This PR adds support for HDF5 dimension scales that have a null dataset, which are handled as netCDF dimensions but not netCDF variables. I'll push an update to the CHANGELOG if you support this enhancement and I've responded to any changes you would like.

Currently h5netcdf throws this error when encountering a dimension scale with null dataset:

```
  File "h5netcdf/h5netcdf/dimensions.py", line 232, in __len__
    return self._h5ds.shape[0]
TypeError: 'NoneType' object is not subscriptable
```
The `NoneType` is expected on a dimension scale with null dataset. The core of my PR is a change to the `Dimension.size` property:

```
@@ -108,7 +110,24 @@ class Dimension(object):
     @property
     def size(self):
         """Return dimension size."""
-        size = len(self)
+        vars = self._parent._h5group["/"]
+        if not self._phony and self._h5ds.shape is None:
+            # the dimension is a null dataset, essentially just a shared name,
+            # and is only compatible with netCDF4 if all axes that reference
+            # the dimension have the same length
+            try:
+                reflist = self._h5ds.attrs["REFERENCE_LIST"]
+            except KeyError:
+                msg = f"Dimension {self.name!r} has no discernable length."
+                raise CompatibilityError(msg)
+            ref_size = {vars[ref].shape[axis] for ref, axis in reflist}
+            try:
+                (size, ) = ref_size
+            except ValueError:
+                msg = f"Dimension {self.name!r} references axes of unequal length."
+                raise CompatibilityError(msg)
+        else:
+            size = len(self)
```

However, changes to the following were required to ensure all tests passed.
- `_netcdf_dimension_but_not_variable`
- `CompatibilityError` moved to h5netcdf.utils
- `Group` initialization tests for adding variables

