### PR TITLE
Remove setuptools_scm_git_archive as it's obsolete

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,6 @@ requires = [
     "setuptools>=42",
     "wheel",
     "setuptools_scm[toml]>=6.2",
-    "setuptools_scm_git_archive",
 ]
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
From the project [README](https://github.com/Changaco/setuptools_scm_git_archive):

```
This plugin is obsolete. ``setuptools_scm >= 7.0.0`` supports Git archives by itself.
```

Similiar issue with [this](https://github.com/fonttools/pyclipper/pull/49). [One package is affected with this change](https://aur.archlinux.org/packages/python-h5netcdf).