### PR TITLE
Add use_scm_version=True to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     url="https://h5netcdf.org",
     python_requires=">=3.8",
     setup_requires=["setuptools_scm"],
+    use_scm_version=True,
     install_requires=["h5py", "packaging"],
     tests_require=["netCDF4", "pytest"],
     packages=find_packages(),


### PR DESCRIPTION
Should fix https://github.com/conda-forge/h5netcdf-feedstock/issues/42 for newer releases.

<!-- Feel free to remove check-list items which aren't relevant to your changes -->

- [ ] Closes Issue #xxxx
- [ ] Tests added
- [ ] Changes are documented in `CHANGELOG.rst`
