### PR TITLE
MNT: move to setup-micromamba in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,10 +51,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install micromamba
-      uses: mamba-org/provision-with-micromamba@main
+      uses: mamba-org/setup-micromamba@v1
       with:
         environment-name: h5netcdf-tests
-        extra-specs: |
+        cache-environment: true
+        cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-h5py${{matrix.h5py_version}}-${{env.TODAY}}"
+        create-args: >-
           python=${{ matrix.python-version }}
           pip
           pytest
@@ -82,10 +84,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install micromamba
-      uses: mamba-org/provision-with-micromamba@main
+      uses: mamba-org/setup-micromamba@v1
       with:
         environment-name: h5netcdf-tests
-        extra-specs: |
+        cache-environment: true
+        cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-h5pyd-${{env.TODAY}}"
+        create-args: >-
           python=${{ matrix.python-version }}
           pip
           pytest
@@ -95,7 +99,6 @@ jobs:
       run: |
         python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
         python -m pip install git+https://github.com/HDFGroup/hsds.git
-        python -m pip install git+https://github.com/HDFGroup/h5pyd.git
     - name: Test with pytest
       run: |
         pytest -v --durations=0 h5netcdf/tests/
@@ -114,10 +117,12 @@ jobs:
     steps:
     - uses: actions/checkout@v3
     - name: Install micromamba
-      uses: mamba-org/provision-with-micromamba@main
+      uses: mamba-org/setup-micromamba@v1
       with:
         environment-name: h5netcdf-tests
-        extra-specs: |
+        cache-environment: true
+        cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-netcdf4_nightly-${{env.TODAY}}"
+        create-args: >-
           python=${{ matrix.python-version }}
           pip
           pytest
@@ -150,12 +155,12 @@ jobs:
         repository: "pydata/xarray"
         fetch-depth: 0
     - name: Install micromamba
-      uses: mamba-org/provision-with-micromamba@main
+      uses: mamba-org/setup-micromamba@v1
       with:
-        channels: conda-forge
-        environment-file: false
         environment-name: h5netcdf-tests
-        extra-specs: |
+        cache-environment: true
+        cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-xarray_nightly-${{env.TODAY}}"
+        create-args: >-
           python=${{ matrix.python-version }}
           dask
           h5py
@@ -186,10 +191,12 @@ jobs:
       with:
         fetch-depth: 0
     - name: Install micromamba
-      uses: mamba-org/provision-with-micromamba@main
+      uses: mamba-org/setup-micromamba@v1
       with:
         environment-name: h5netcdf-docs
-        extra-specs: |
+        cache-environment: true
+        cache-environment-key: "${{runner.os}}-${{runner.arch}}-py${{env.PYTHON_VERSION}}-docs-${{env.TODAY}}"
+        create-args: >-
           python=3.11
           pip
           pytest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -230,7 +230,7 @@ jobs:
 
   upload-pypi:
     if: github.event_name == 'release'
-    needs: [lint, build_1, sphinx_doc]
+    needs: [lint, build_0, sphinx_doc]
     name: deploy to pypi
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -203,6 +203,7 @@ jobs:
           pip
           pytest
           wheel
+          h5py
           netCDF4
           sphinx
           sphinx-book-theme>=0.3.2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,6 +100,7 @@ jobs:
       run: |
         python -m pip install . --no-deps --ignore-installed --no-cache-dir -vvv
         python -m pip install git+https://github.com/HDFGroup/hsds.git
+        python -m pip install git+https://github.com/HDFGroup/h5pyd.git
     - name: Test with pytest
       run: |
         pytest -v --durations=0 h5netcdf/tests/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,6 +94,7 @@ jobs:
           pip
           pytest
           wheel
+          h5py
           netCDF4
     - name: Install h5netcdf
       run: |
@@ -127,6 +128,7 @@ jobs:
           pip
           pytest
           wheel
+          h5py
           libnetcdf
           cftime
     - name: Install netCDF4 from GitHub

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,8 @@ Development Version:
   `Mark Harfouche <https://github.com/hmaarrfk>`_.
 - Update to pyproject.toml-only build process, adapt CI, use `ruff` for linting, add .pre-commit-config.yaml.
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_
+- Maintenance CI (use setup-micromamba), fix hsds, fix tests, fix license
+  By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_
 
 
 Version 1.1.0 (November 23rd, 2022):

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -173,11 +173,10 @@ class BaseVariable:
                 # if unlabeled dimensions are found
                 if self._root._phony_dims_mode is None:
                     raise ValueError(
-                        "variable %r has no dimension scale "
-                        "associated with axis %s. \n"
-                        "Use phony_dims=%r for sorted naming or "
-                        "phony_dims=%r for per access naming."
-                        % (self.name, axis, "sort", "access")
+                        f"variable {self.name!r} has no dimension scale "
+                        f"associated with axis {axis}. \n"
+                        f"Use phony_dims='sort' for sorted naming or "
+                        f"phony_dims='access' for per access naming."
                     )
                 else:
                     # get current dimension
@@ -933,17 +932,16 @@ class Group(Mapping):
         return (
             ["Dimensions:"]
             + [
-                "    %s: %s"
-                % (
+                "    {}: {}".format(
                     k,
-                    ("Unlimited (current: %s)" % self._dimensions[k].size)
+                    f"Unlimited (current: {self._dimensions[k].size})"
                     if v is None
                     else v,
                 )
                 for k, v in self.dimensions.items()
             ]
             + ["Groups:"]
-            + ["    %s" % g for g in self.groups]
+            + [f"    {g}" for g in self.groups]
             + ["Variables:"]
             + [
                 f"    {k}: {v.dimensions!r} {v.dtype}"
@@ -955,7 +953,7 @@ class Group(Mapping):
 
     def __repr__(self):
         if self._root._closed:
-            return "<Closed %s>" % self._cls_name
+            return f"<Closed {self._cls_name}>"
         header = f"<{self._cls_name} {self.name!r} ({len(self)} members)>"
         return "\n".join([header] + self._repr_body())
 
@@ -1075,10 +1073,9 @@ class File(Group):
             self._phony_dim_count = 0
             if phony_dims not in ["sort", "access"]:
                 raise ValueError(
-                    "unknown value %r for phony_dims\n"
-                    "Use phony_dims=%r for sorted naming, "
-                    "phony_dims=%r for per access naming."
-                    % (phony_dims, "sort", "access")
+                    f"unknown value {phony_dims!r} for phony_dims\n"
+                    "Use phony_dims='sort' for sorted naming, "
+                    "phony_dims='access' for per access naming."
                 )
 
         # string decoding

--- a/h5netcdf/tests/conftest.py
+++ b/h5netcdf/tests/conftest.py
@@ -26,7 +26,7 @@ def set_hsds_root():
     sys.argv.extend(["-e", os.environ["HS_ENDPOINT"]])
     sys.argv.extend(["-u", "admin"])
     sys.argv.extend(["-p", "admin"])
-    sys.argv.extend(["-b", os.environ["BUCKET_NAME"]])
+    sys.argv.extend(["--bucket", os.environ["BUCKET_NAME"]])
     sys.argv.append("/home/")
     hstouch()
 
@@ -34,7 +34,7 @@ def set_hsds_root():
     sys.argv.extend(["-e", os.environ["HS_ENDPOINT"]])
     sys.argv.extend(["-u", "admin"])
     sys.argv.extend(["-p", "admin"])
-    sys.argv.extend(["-b", os.environ["BUCKET_NAME"]])
+    sys.argv.extend(["--bucket", os.environ["BUCKET_NAME"]])
     sys.argv.extend(["-o", os.environ["HS_USERNAME"]])
     sys.argv.append(f'/home/{os.environ["HS_USERNAME"]}/')
     hstouch()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "setuptools.build_meta"
 name = "h5netcdf"
 description = "netCDF4 via h5py"
 requires-python = ">=3.9"
-license = {file = "LICENSE.txt"}
+license = {file = "LICENSE"}
 authors = [
     { name = "Stephan Hoyer", email = "shoyer@gmail.com" },
     { name = "Kai Mühlbauer", email = "kmuehlbauer@wradlib.org" },


### PR DESCRIPTION
This replaces the deprecated https://github.com/mamba-org/provision-with-micromamba with it's successor https://github.com/mamba-org/setup-micromamba

<!-- Feel free to remove check-list items which aren't relevant to your changes -->

- [ ] Changes are documented in `CHANGELOG.rst`
