### PR TITLE
Allow to use ros3 driver for remote url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Change Log
 ----------
 
+Development Version:
+
+- Add ros3 support by checking `driver`-kwarg.
+  By `Ezequiel Cimadevilla Alvarez <https://github.com/zequihg50>`_
+
 Version 1.2.0 (June 2nd, 2023):
 
 - Remove h5py2 compatibility code, remove h5py2 CI runs, mention NEP29 as

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -1029,7 +1029,10 @@ class File(Group):
         self.decode_vlen_strings = kwargs.pop("decode_vlen_strings", None)
         try:
             if isinstance(path, str):
-                if path.startswith(("http://", "https://", "hdf5://")) and "driver" not in kwargs:
+                if (
+                    path.startswith(("http://", "https://", "hdf5://"))
+                    and "driver" not in kwargs
+                ):
                     if no_h5pyd:
                         raise ImportError(
                             "No module named 'h5pyd'. h5pyd is required for "

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -1029,7 +1029,7 @@ class File(Group):
         self.decode_vlen_strings = kwargs.pop("decode_vlen_strings", None)
         try:
             if isinstance(path, str):
-                if path.startswith(("http://", "https://", "hdf5://")):
+                if path.startswith(("http://", "https://", "hdf5://")) and "driver" not in kwargs:
                     if no_h5pyd:
                         raise ImportError(
                             "No module named 'h5pyd'. h5pyd is required for "

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -2176,7 +2176,9 @@ def test_vlen_string_dataset_fillvalue(tmp_local_netcdf, decode_vlen_strings):
         assert ds["x1"]._FillValue == fill_value1
 
 
-@pytest.mark.skipif("ros3" not in h5py.registered_drivers())
+@pytest.mark.skipif(
+    "ros3" not in h5py.registered_drivers(), reason="ros3 not available"
+)
 def test_ros3():
     fname = (
         "https://www.unidata.ucar.edu/software/netcdf/examples/OMI-Aura_L2-example.nc"

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -2174,3 +2174,10 @@ def test_vlen_string_dataset_fillvalue(tmp_local_netcdf, decode_vlen_strings):
         assert ds["x0"]._FillValue == fill_value0
         assert ds["x1"][0] == fill_value1
         assert ds["x1"]._FillValue == fill_value1
+
+
+def test_ros3():
+    fname = "https://www.unidata.ucar.edu/software/netcdf/examples/OMI-Aura_L2-example.nc"
+    f = h5netcdf.File(fname, "r", driver="ros3")
+    assert "Temperature" in list(f)
+    f.close()

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -2176,8 +2176,11 @@ def test_vlen_string_dataset_fillvalue(tmp_local_netcdf, decode_vlen_strings):
         assert ds["x1"]._FillValue == fill_value1
 
 
+@pytest.mark.skipif("ros3" not in h5py.registered_drivers())
 def test_ros3():
-    fname = "https://www.unidata.ucar.edu/software/netcdf/examples/OMI-Aura_L2-example.nc"
+    fname = (
+        "https://www.unidata.ucar.edu/software/netcdf/examples/OMI-Aura_L2-example.nc"
+    )
     f = h5netcdf.File(fname, "r", driver="ros3")
     assert "Temperature" in list(f)
     f.close()


### PR DESCRIPTION
Currently, for remote URLs `hpy5d` is used. However, it is desirable to allow the usage of the `ros3` HDF5 driver to read from remote URLs.

The following code does not work at the moment.

```python
import h5netcdf

f = h5netcdf.File("https://api.cloud.ifca.es:8080/swift/v1/IPCC-IA-Monthly/test2.nc", driver="ros3")
print(list(f))
```

This simple pull request allows to use the `ros3` driver with `h5py` ignoring `h5pyd`.