### PR TITLE
Use cached properties to speed up dataset access

### DIFF
--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -548,7 +548,7 @@ class Group(Mapping):
     def _parent(self):
         return self._parent_ref()
 
-    @property
+    @cached_property
     def _h5group(self):
         # Always refer to the root file and store not h5py object
         # subclasses:

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -109,18 +109,19 @@ def _expanded_indexer(key, ndim):
 
 class BaseVariable:
     def __init__(self, parent, name, dimensions=None):
-        self._parent = parent
+        self._parent_ref = weakref.ref(parent)
+        self._root_ref = weakref.ref(parent._root)
         self._h5path = _join_h5paths(parent.name, name)
         self._dimensions = dimensions
         self._initialized = True
 
     @cached_property
     def _parent(self):
-        return self._parent
+        return self._parent_ref()
 
     @cached_property
     def _root(self):
-        return self._parent._root
+        return self._root_ref()
 
     @cached_property
     def _h5ds(self):
@@ -411,7 +412,7 @@ class _LazyObjectLookup(Mapping):
         self._object_cls = object_cls
         self._objects = OrderedDict()
 
-    @property
+    @cached_property
     def _parent(self):
         return self._parent_ref()
 

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -109,19 +109,18 @@ def _expanded_indexer(key, ndim):
 
 class BaseVariable:
     def __init__(self, parent, name, dimensions=None):
-        self._parent_ref = weakref.ref(parent)
-        self._root_ref = weakref.ref(parent._root)
+        self._parent = parent
         self._h5path = _join_h5paths(parent.name, name)
         self._dimensions = dimensions
         self._initialized = True
 
-    @property
+    @cached_property
     def _parent(self):
-        return self._parent_ref()
+        return self._parent
 
-    @property
+    @cached_property
     def _root(self):
-        return self._root_ref()
+        return self._parent._root
 
     @cached_property
     def _h5ds(self):

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -1068,7 +1068,6 @@ class File(Group):
 
         self._mode = mode
         self._writable = mode != "r"
-        self._root_ref = weakref.ref(self)
         self._h5path = "/"
         self.invalid_netcdf = invalid_netcdf
 

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -128,7 +128,7 @@ class BaseVariable:
         # subclasses:
         return self._root._h5file[self._h5path]
 
-    @property
+    @cached_property
     def name(self):
         """Return variable name."""
         # fix name if _nc4_non_coord_
@@ -253,7 +253,7 @@ class BaseVariable:
         if self._h5ds.shape != new_shape:
             self._h5ds.resize(new_shape)
 
-    @property
+    @cached_property
     def dimensions(self):
         """Return variable dimension names."""
         if self._dimensions is None:
@@ -266,7 +266,7 @@ class BaseVariable:
         # return actual dimensions sizes, this is in line with netcdf4-python
         return tuple([self._parent._all_dimensions[d].size for d in self.dimensions])
 
-    @property
+    @cached_property
     def ndim(self):
         """Return number variable dimensions"""
         return len(self.shape)
@@ -274,7 +274,7 @@ class BaseVariable:
     def __len__(self):
         return self.shape[0]
 
-    @property
+    @cached_property
     def dtype(self):
         """Return NumPy dtype object giving the variable’s type."""
         return self._h5ds.dtype
@@ -357,7 +357,7 @@ class BaseVariable:
             self._maybe_resize_dimensions(key, value)
         self._h5ds[key] = value
 
-    @property
+    @cached_property
     def attrs(self):
         """Return variable attributes."""
         return Attributes(

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -554,7 +554,7 @@ class Group(Mapping):
         # subclasses:
         return self._root._h5file[self._h5path]
 
-    @property
+    @cached_property
     def _track_order(self):
         if self._root._h5py.__name__ == "h5pyd":
             return False
@@ -569,7 +569,7 @@ class Group(Mapping):
         order_indexed = bool(attr_creation_order & CRT_ORDER_INDEXED)
         return order_tracked and order_indexed
 
-    @property
+    @cached_property
     def name(self):
         from .legacyapi import Dataset
 
@@ -902,7 +902,7 @@ class Group(Mapping):
     def __len__(self):
         return len(self.variables) + len(self.groups)
 
-    @property
+    @cached_property
     def parent(self):
         return self._parent
 

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -5,6 +5,7 @@ import warnings
 import weakref
 from collections import ChainMap, Counter, OrderedDict, defaultdict
 from collections.abc import Mapping
+from functools import cached_property
 
 import h5py
 import numpy as np
@@ -122,7 +123,7 @@ class BaseVariable:
     def _root(self):
         return self._root_ref()
 
-    @property
+    @cached_property
     def _h5ds(self):
         # Always refer to the root file and store not h5py object
         # subclasses:


### PR DESCRIPTION
My use case involves using `h5netcdf` to read geostationary satellite data in the Satpy library. The data, new geostationary Meteosat FCI instrument by EUMETSAT, has a very complicated NetCDF4 structure split over 80 separate files. The complicated structure prevents us from using `xr.open_dataset()` as we'd end up having tens of thousands of open file handles.

For local reading we are using `netCDF4-python`, but to get remote access (e.g. from a local CEPH/S3) via `fsspec` we are using `h5netcdf`. Just collecting the metadata from local files (creating a `Scene` object in Satpy) using `h5netcdf` takes 36 seconds. As a reference, `netCDF4-python` also uses 10 seconds for this, which already tells how complex the files are.

The discussion in #195 and the work on speeding up in #197 has been of great value when trying to understand the causes. 

Inspired by these I had a look, and added some caching for some properties in `h5netcdf.core` and 10 seconds from the execution time with the tradeoff of using 1100 MB of RAM instead of 800 MB using the current `main`.

The biggest gain came from caching the `BaseVariable._h5ds` property.

I could get still few seconds of caching more, but then I encounter test failure (in `h5netcdf/tests/test_h5netcdf.py::test_no_circular_references` having 2 references instead of the 1 asserted in the tests) that I didn't want to tweak.

- [ ] Closes Issue #xxxx
- [ ] Tests added
- [ ] Changes are documented in `CHANGELOG.rst`
