### PR TITLE
Allow zlib to be an alias for gzip

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,8 @@ Development Version (unreleased):
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_
 - Update CI and reinstate h5pyd/hsds test runs ({pull}`247`).
   By `John Readey  <https://github.com/jreadey>`_
+- Allow ``zlib`` to be used as an alias for ``gzip`` for enhanced compatibility with h5netcdf's API and xarray.
+  By `Mark Harfouche <https://github.com/hmaarrfk>`_
 
 Version 1.4.1 (November 13th, 2024):
 

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -1185,7 +1185,7 @@ class Group(Mapping):
         compression : str, optional
             Compression filter to apply, defaults to ``gzip``. ``zlib`` is an alias for ``gzip``.
         compression_opts : int
-            Parameter for compression filter. For ``compression="gzip"`` Integer from 1 to 9 specifying
+            Parameter for compression filter. For ``compression="gzip"``/``compression="zlib"`` Integer from 1 to 9 specifying
             the compression level. Defaults to 4.
         fletcher32 : bool
             If ``True``, HDF5 Fletcher32 checksum algorithm is applied. Defaults to ``False``.

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -1183,7 +1183,7 @@ class Group(Mapping):
             ``h5netcdf``. Discussion on ``h5netcdf`` chunking can be found in (:issue:`52`)
             and (:pull:`127`).
         compression : str, optional
-            Compression filter to apply, defaults to ``gzip``
+            Compression filter to apply, defaults to ``gzip``. ``zlib`` is an alias for ``gzip``.
         compression_opts : int
             Parameter for compression filter. For ``compression="gzip"`` Integer from 1 to 9 specifying
             the compression level. Defaults to 4.
@@ -1232,6 +1232,13 @@ class Group(Mapping):
         group = self
         for k in keys[:-1]:
             group = group._require_child_group(k)
+
+        # Allow zlib to be an alias for gzip
+        # but use getters and setters so as not to change the behavior
+        # of the default h5py functions
+        if kwargs.get("compression", None) == "zlib":
+            kwargs["compression"] = "gzip"
+
         return group._create_child_variable(
             keys[-1],
             dimensions,

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -186,14 +186,14 @@ def write_legacy_netcdf(tmp_netcdf, write_module):
     ds.close()
 
 
-def write_h5netcdf(tmp_netcdf):
+def write_h5netcdf(tmp_netcdf, compression="gzip"):
     ds = h5netcdf.File(tmp_netcdf, "w")
     ds.attrs["global"] = 42
     ds.attrs["other_attr"] = "yes"
     ds.dimensions = {"x": 4, "y": 5, "z": 6, "empty": 0, "unlimited": None}
 
     v = ds.create_variable(
-        "foo", ("x", "y"), float, chunks=(4, 5), compression="gzip", shuffle=True
+        "foo", ("x", "y"), float, chunks=(4, 5), compression=compression, shuffle=True
     )
     v[...] = 1
     v.attrs["units"] = "meters"
@@ -515,6 +515,11 @@ def test_write_h5netcdf_read_netCDF4(tmp_local_netcdf):
 def test_roundtrip_h5netcdf(tmp_local_or_remote_netcdf, decode_vlen_strings):
     write_h5netcdf(tmp_local_or_remote_netcdf)
     read_h5netcdf(tmp_local_or_remote_netcdf, h5netcdf, decode_vlen_strings)
+
+
+def test_write_compression_as_zlib(tmp_local_netcdf):
+    write_h5netcdf(tmp_local_netcdf, compression="zlib")
+    read_legacy_netcdf(tmp_local_netcdf, netCDF4, h5netcdf)
 
 
 def test_write_netCDF4_read_h5netcdf(tmp_local_netcdf, decode_vlen_strings):


### PR DESCRIPTION
libnetcdf4 allows zlib to be passed in as a compression string.

In xarray one would typically allow 'zlib' to be specified in

encoding['compression'] = 'zlib'

but the problem is that h5netcdf won't support this syntax.

This builds that compatibility layer

not quite related but: https://github.com/h5netcdf/h5netcdf/issues/240

- [x] Tests added
- [x] Changes are documented in `CHANGELOG.rst`
