### PR TITLE
Add partial support for NETCDF4_CLASSIC format

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@ Development Version (unreleased):
 
 - Fix unintentional changes in test suite (:pull:`277`).
   By `Kai Mühlbauer <https://github.com/kmuehlbauer>`_
+- Add the `format` argument to `h5netcdf.File` and partial support for the `NETCDF4_CLASSIC` format (:issue:`280`, :pull:``).
+  By `David Huard <https://github.com/huard>`_
 
 Version 1.6.4 (August 5th, 2025):
 

--- a/h5netcdf/core.py
+++ b/h5netcdf/core.py
@@ -983,7 +983,7 @@ class Group(Mapping):
             unlimited_dims = list(filter(lambda s: s in [None, 0], value.values()))
             if len(unlimited_dims) > 1:
                 raise CompatibilityError(
-                    "NETCDF4_CLASSIC format only allows one unlimited dimension"
+                    "NETCDF4_CLASSIC format only allows one unlimited dimension."
                 )
 
         for k, v in self._all_dimensions.maps[0].items():
@@ -1229,7 +1229,6 @@ class Group(Mapping):
 
             if self._root._format == "NETCDF4_CLASSIC" and len(dimensions) == 0:
                 raise CompatibilityError(
-                    "NETCDF4_CLASSIC format does not allow variables without dimensions."
                     "NETCDF4_CLASSIC format does not allow variables without dimensions."
                 )
 

--- a/h5netcdf/dimensions.py
+++ b/h5netcdf/dimensions.py
@@ -84,6 +84,7 @@ class Dimension:
         self._h5path = _join_h5paths(parent.name, name)
         self._name = name
         self._size = 0 if size is None else size
+
         if self._phony:
             self._root._phony_dim_count += 1
         else:

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -76,6 +76,11 @@ def netcdf_write_module(request):
     return request.param
 
 
+@pytest.fixture(params=["NETCDF4", "NETCDF4_CLASSIC"])
+def format(request):
+    return dict(format=request.param)
+
+
 def get_hdf5_module(resource):
     """Return the correct h5py module based on the input resource."""
     if isinstance(resource, str) and resource.startswith(remote_h5):
@@ -83,6 +88,37 @@ def get_hdf5_module(resource):
     else:
         return h5py
 
+
+def h5dump(fn: str):
+    """Call h5dump on an h5netcdf file."""
+    import subprocess
+
+    out = subprocess.run(
+        ["h5dump", "-A", "-B", fn], check=False, capture_output=True
+    ).stdout.decode()
+
+    # Strip first and last line
+    # HDF5 "file" {
+    # ...
+    # }
+    return "\n".join(out.splitlines()[1:-1])
+
+    #
+    # @requires_netCDF4
+    # def test_h5dump(self, tmp_path) -> None:
+    #     data = create_test_data()
+    #
+    #     # Dump the representation of the netCDF4-generated file
+    #     fn = tmp_path / "netcdf4.nc"
+    #     data.to_netcdf(fn, engine="netcdf4", format=self.file_format)
+    #     expected = _h5dump(fn)
+    #
+    #     # Dump the representation of the h5netcdf-generated file
+    #     fn = tmp_path / "h5netcdf.nc"
+    #     data.to_netcdf(fn, engine=self.engine, format=self.file_format)
+    #     actual = _h5dump(fn)
+    #
+    #     assert expected == actual
 
 def string_to_char(arr):
     """Like nc4.stringtochar, but faster and more flexible."""
@@ -133,22 +169,27 @@ def is_h5py_char_working(tmp_netcdf, name):
             raise
 
 
-def write_legacy_netcdf(tmp_netcdf, write_module):
-    ds = write_module.Dataset(tmp_netcdf, "w")
-    ds.setncattr("global", 42)
+def write_legacy_netcdf(tmp_netcdf, write_module, format="NETCDF4"):
+    ds = write_module.Dataset(tmp_netcdf, mode="w", format=format)
+    intf = np.int64 if format == "NETCDF4" else np.int32
+
+    ds.setncattr("global", intf(42))
     ds.other_attr = "yes"
     ds.createDimension("x", 4)
     ds.createDimension("y", 5)
     ds.createDimension("z", 6)
-    ds.createDimension("empty", 0)
     ds.createDimension("string3", 3)
     ds.createDimension("unlimited", None)
+
+    if format == "NETCDF4":
+        # In the CLASSIC format, only one unlimited dimension is allowed
+        ds.createDimension("empty", 0)
 
     v = ds.createVariable("foo", float, ("x", "y"), chunksizes=(4, 5), zlib=True)
     v[...] = 1
     v.setncattr("units", "meters")
 
-    v = ds.createVariable("y", int, ("y",), fill_value=-1)
+    v = ds.createVariable("y", intf, ("y",), fill_value=intf(-1))
     v[:4] = np.arange(4)
 
     v = ds.createVariable("z", "S1", ("z", "string3"), fill_value=b"X")
@@ -158,7 +199,7 @@ def write_legacy_netcdf(tmp_netcdf, write_module):
     v[...] = 2.0
 
     # test creating a scalar with compression option (with should be ignored)
-    v = ds.createVariable("intscalar", np.int64, (), zlib=6, fill_value=None)
+    v = ds.createVariable("intscalar", intf, (), zlib=6, fill_value=None)
     v[...] = 2
 
     v = ds.createVariable("foo_unlimited", float, ("x", "unlimited"))
@@ -170,37 +211,57 @@ def write_legacy_netcdf(tmp_netcdf, write_module):
     ):
         ds.createVariable("boolean", np.bool_, ("x"))
 
-    g = ds.createGroup("subgroup")
-    v = g.createVariable("subvar", np.int32, ("x",))
-    v[...] = np.arange(4.0)
-
-    g.createDimension("y", 10)
-    g.createVariable("y_var", float, ("y",))
-
     ds.createDimension("mismatched_dim", 1)
-    ds.createVariable("mismatched_dim", int, ())
+    ds.createVariable("mismatched_dim", intf, ())
 
-    v = ds.createVariable("var_len_str", str, ("x"))
-    v[0] = "foo"
+    if format == "NETCDF4":
+        g = ds.createGroup("subgroup")
+        v = g.createVariable("subvar", np.int32, ("x",))
+        v[...] = np.arange(4.0)
 
-    enum_dict = dict(one=1, two=2, three=3, missing=255)
-    enum_type = ds.createEnumType(np.uint8, "enum_t", enum_dict)
-    v = ds.createVariable(
-        "enum_var",
-        enum_type,
-        ("x",),
-        fill_value=enum_dict["missing"],
-    )
-    v[0:3] = [1, 2, 3]
+        g.createDimension("y", 10)
+        g.createVariable("y_var", float, ("y",))
+
+        v = ds.createVariable("var_len_str", str, ("x"))
+        v[0] = "foo"
+
+        enum_dict = dict(one=1, two=2, three=3, missing=255)
+        enum_type = ds.createEnumType(np.uint8, "enum_t", enum_dict)
+        v = ds.createVariable(
+            "enum_var",
+            enum_type,
+            ("x",),
+            fill_value=enum_dict["missing"],
+        )
+        v[0:3] = [1, 2, 3]
 
     ds.close()
 
 
-def write_h5netcdf(tmp_netcdf, compression="gzip"):
-    ds = h5netcdf.File(tmp_netcdf, "w")
-    ds.attrs["global"] = 42
+def write_h5netcdf(tmp_netcdf, compression="gzip", format="NETCDF4"):
+    ds = h5netcdf.File(tmp_netcdf, mode="w", format=format)
+    intf = np.int64 if format == "NETCDF4" else np.int32
+    ds.attrs["global"] = intf(42)
     ds.attrs["other_attr"] = "yes"
-    ds.dimensions = {"x": 4, "y": 5, "z": 6, "empty": 0, "unlimited": None}
+
+    if format == "NETCDF4_CLASSIC":
+        with raises(CompatibilityError):
+            ds.dimensions = {"x": 4, "y": 5, "z": 6, "unlimited": None, "empty": 0}
+
+    ds.dimensions = {"x": 4, "y": 5, "z": 6, "unlimited": None}
+
+    if format == "NETCDF4":
+        ds.dimensions["empty"] = 0
+
+    if format == "NETCDF4_CLASSIC":
+        with raises(CompatibilityError):
+            ds.dimensions["empty"] = 0
+
+        with raises(CompatibilityError):
+            ds.attrs["int64_attr"] = 42
+
+        # with raises(CompatibilityError):
+        #     ds.create_variable("mismatched_dim", (), dtype=intf)
 
     v = ds.create_variable(
         "foo", ("x", "y"), float, chunks=(4, 5), compression=compression, shuffle=True
@@ -210,14 +271,14 @@ def write_h5netcdf(tmp_netcdf, compression="gzip"):
 
     remote_file = isinstance(tmp_netcdf, str) and tmp_netcdf.startswith(remote_h5)
     if not remote_file:
-        v = ds.create_variable("y", ("y",), int, fillvalue=-1)
+        v = ds.create_variable("y", ("y",), intf, fillvalue=intf(-1))
         v[:4] = np.arange(4)
 
     v = ds.create_variable("z", ("z", "string3"), data=_char_array, fillvalue=b"X")
 
     v = ds.create_variable("scalar", data=np.float32(2.0))
 
-    v = ds.create_variable("intscalar", data=np.int64(2))
+    v = ds.create_variable("intscalar", data=intf(2))
 
     v = ds.create_variable("foo_unlimited", ("x", "unlimited"), float)
     v[...] = 1
@@ -225,36 +286,45 @@ def write_h5netcdf(tmp_netcdf, compression="gzip"):
     with raises((h5netcdf.CompatibilityError, TypeError)):
         ds.create_variable("boolean", data=True)
 
-    g = ds.create_group("subgroup")
-    v = g.create_variable("subvar", ("x",), np.int32)
-    v[...] = np.arange(4.0)
-    with raises(AttributeError):
-        v.attrs["_Netcdf4Dimid"] = -1
-
-    g.dimensions["y"] = 10
-    g.create_variable("y_var", ("y",), float)
-    g.flush()
-
     ds.dimensions["mismatched_dim"] = 1
-    ds.create_variable("mismatched_dim", dtype=int)
+    ds.create_variable("mismatched_dim", dtype=intf)
     ds.flush()
 
-    dt = h5py.special_dtype(vlen=str)
-    v = ds.create_variable("var_len_str", ("x",), dtype=dt)
-    v[0] = _vlen_string
+    if format == "NETCDF4":
+        g = ds.create_group("subgroup")
+        v = g.create_variable("subvar", ("x",), np.int32)
+        v[...] = np.arange(4.0)
+        with raises(AttributeError):
+            v.attrs["_Netcdf4Dimid"] = -1
 
-    enum_dict = dict(one=1, two=2, three=3, missing=255)
-    enum_type = ds.create_enumtype(np.uint8, "enum_t", enum_dict)
-    v = ds.create_variable(
-        "enum_var", ("x",), dtype=enum_type, fillvalue=enum_dict["missing"]
-    )
-    v[0:3] = [1, 2, 3]
+        g.dimensions["y"] = 10
+        g.create_variable("y_var", ("y",), float)
+        g.flush()
+
+        dt = h5py.special_dtype(vlen=str)
+        v = ds.create_variable("var_len_str", ("x",), dtype=dt)
+        v[0] = _vlen_string
+
+        enum_dict = dict(one=1, two=2, three=3, missing=255)
+        enum_type = ds.create_enumtype(np.uint8, "enum_t", enum_dict)
+        v = ds.create_variable(
+            "enum_var", ("x",), dtype=enum_type, fillvalue=enum_dict["missing"]
+        )
+        v[0:3] = [1, 2, 3]
 
     ds.close()
 
 
 def read_legacy_netcdf(tmp_netcdf, read_module, write_module):
     ds = read_module.Dataset(tmp_netcdf, "r")
+
+    if read_module is netCDF4:
+        format = ds.data_model
+    else:
+        format = ds._format
+
+    intf = np.int64 if format == "NETCDF4" else np.int32
+
     assert ds.ncattrs() == ["global", "other_attr"]
     assert ds.getncattr("global") == 42
     if write_module is not netCDF4:
@@ -262,52 +332,57 @@ def read_legacy_netcdf(tmp_netcdf, read_module, write_module):
         assert ds.other_attr == "yes"
     with raises(AttributeError, match="not found"):
         ds.does_not_exist
-    assert set(ds.dimensions) == {
+    dimensions = {
         "x",
         "y",
         "z",
-        "empty",
         "string3",
         "mismatched_dim",
         "unlimited",
     }
-    assert set(ds.variables) == {
-        "enum_var",
+    variables = {
         "foo",
         "y",
         "z",
         "intscalar",
         "scalar",
-        "var_len_str",
-        "mismatched_dim",
         "foo_unlimited",
+        "mismatched_dim",
     }
+    if format == "NETCDF4":
+        dimensions |= {"empty"}
+        variables |= {"enum_var", "var_len_str", }
 
-    assert set(ds.enumtypes) == {"enum_t"}
+    assert set(ds.dimensions) == dimensions
+    assert set(ds.variables) == variables
 
-    assert set(ds.groups) == {"subgroup"}
-    assert ds.parent is None
-    v = ds.variables["foo"]
-    assert array_equal(v, np.ones((4, 5)))
-    assert v.dtype == float
-    assert v.dimensions == ("x", "y")
-    assert v.ndim == 2
-    assert v.ncattrs() == ["units"]
-    if write_module is not netCDF4:
-        assert v.getncattr("units") == "meters"
-    assert tuple(v.chunking()) == (4, 5)
+    if format == "NETCDF4":
+        assert set(ds.enumtypes) == {"enum_t"}
 
-    # check for dict items separately
-    # see https://github.com/h5netcdf/h5netcdf/issues/171
-    filters = v.filters()
-    assert filters["complevel"] == 4
-    assert filters["fletcher32"] is False
-    assert filters["shuffle"] is True
-    assert filters["zlib"] is True
+        assert set(ds.groups) == {"subgroup"}
+        assert ds.parent is None
+        v = ds.variables["foo"]
+        assert array_equal(v, np.ones((4, 5)))
+        assert v.dtype == float
+        assert v.dimensions == ("x", "y")
+        assert v.ndim == 2
+        assert v.ncattrs() == ["units"]
+
+        if write_module is not netCDF4:
+            assert v.getncattr("units") == "meters"
+        assert tuple(v.chunking()) == (4, 5)
+
+        # check for dict items separately
+        # see https://github.com/h5netcdf/h5netcdf/issues/171
+        filters = v.filters()
+        assert filters["complevel"] == 4
+        assert filters["fletcher32"] is False
+        assert filters["shuffle"] is True
+        assert filters["zlib"] is True
 
     v = ds.variables["y"]
     assert array_equal(v, np.r_[np.arange(4), [-1]])
-    assert v.dtype == int
+    assert v.dtype == intf
     assert v.dimensions == ("y",)
     assert v.ndim == 1
     assert v.ncattrs() == ["_FillValue"]
@@ -347,32 +422,33 @@ def read_legacy_netcdf(tmp_netcdf, read_module, write_module):
 
     v = ds.variables["intscalar"]
     assert array_equal(v, np.array(2))
-    assert v.dtype == "int64"
+    assert v.dtype == intf
     assert v.ndim == 0
     assert v.dimensions == ()
     assert v.ncattrs() == []
 
-    v = ds.variables["var_len_str"]
-    assert v.dtype == str
-    assert v[0] == _vlen_string
+    if format == "NETCDF4":
+        v = ds.variables["var_len_str"]
+        assert v.dtype == str
+        assert v[0] == _vlen_string
 
-    v = ds.groups["subgroup"].variables["subvar"]
-    assert ds.groups["subgroup"].parent is ds
-    assert array_equal(v, np.arange(4.0))
-    assert v.dtype == "int32"
-    assert v.ndim == 1
-    assert v.dimensions == ("x",)
-    assert v.ncattrs() == []
+        v = ds.groups["subgroup"].variables["subvar"]
+        assert ds.groups["subgroup"].parent is ds
+        assert array_equal(v, np.arange(4.0))
+        assert v.dtype == "int32"
+        assert v.ndim == 1
+        assert v.dimensions == ("x",)
+        assert v.ncattrs() == []
 
-    v = ds.groups["subgroup"].variables["y_var"]
-    assert v.shape == (10,)
-    assert "y" in ds.groups["subgroup"].dimensions
+        v = ds.groups["subgroup"].variables["y_var"]
+        assert v.shape == (10,)
+        assert "y" in ds.groups["subgroup"].dimensions
 
-    enum_dict = dict(one=1, two=2, three=3, missing=255)
-    enum_type = ds.enumtypes["enum_t"]
-    assert enum_type.enum_dict == enum_dict
-    v = ds.variables["enum_var"]
-    assert array_equal(v, np.ma.masked_equal([1, 2, 3, 255], 255))
+        enum_dict = dict(one=1, two=2, three=3, missing=255)
+        enum_type = ds.enumtypes["enum_t"]
+        assert enum_type.enum_dict == enum_dict
+        v = ds.variables["enum_var"]
+        assert array_equal(v, np.ma.masked_equal([1, 2, 3, 255], 255))
 
     ds.close()
 
@@ -380,37 +456,42 @@ def read_legacy_netcdf(tmp_netcdf, read_module, write_module):
 def read_h5netcdf(tmp_netcdf, write_module, decode_vlen_strings):
     remote_file = isinstance(tmp_netcdf, str) and tmp_netcdf.startswith(remote_h5)
     ds = h5netcdf.File(tmp_netcdf, "r", **decode_vlen_strings)
+    format = ds._format
+    intf = np.int64 if format == "NETCDF4" else np.int32
+
     assert ds.name == "/"
     assert list(ds.attrs) == ["global", "other_attr"]
     assert ds.attrs["global"] == 42
     if write_module is not netCDF4:
         # skip for now: https://github.com/Unidata/netcdf4-python/issues/388
         assert ds.attrs["other_attr"] == "yes"
-    assert set(ds.dimensions) == {
+    dimensions = {
         "x",
         "y",
         "z",
-        "empty",
         "string3",
         "mismatched_dim",
         "unlimited",
     }
     variables = {
-        "enum_var",
         "foo",
         "z",
         "intscalar",
         "scalar",
-        "var_len_str",
-        "mismatched_dim",
         "foo_unlimited",
+        "mismatched_dim",
     }
     # fix current failure of hsds/h5pyd
     if not remote_file:
         variables |= {"y"}
+
+    if format == "NETCDF4":
+        dimensions |= {"empty"}
+        variables |= {"enum_var", "var_len_str"}
+
+    assert set(ds.dimensions) == dimensions
     assert set(ds.variables) == variables
 
-    assert set(ds.groups) == {"subgroup"}
     assert ds.parent is None
 
     v = ds["foo"]
@@ -432,7 +513,7 @@ def read_h5netcdf(tmp_netcdf, write_module, decode_vlen_strings):
     if not remote_file:
         v = ds["y"]
         assert array_equal(v, np.r_[np.arange(4), [-1]])
-        assert v.dtype == int
+        assert v.dtype == intf
         assert v.dimensions == ("y",)
         assert v.ndim == 1
         assert list(v.attrs) == ["_FillValue"]
@@ -466,45 +547,48 @@ def read_h5netcdf(tmp_netcdf, write_module, decode_vlen_strings):
 
     v = ds.variables["intscalar"]
     assert array_equal(v, np.array(2))
-    assert v.dtype == "int64"
+    assert v.dtype == intf
     assert v.ndim == 0
     assert v.dimensions == ()
     assert list(v.attrs) == []
 
-    v = ds["var_len_str"]
-    assert h5py.check_dtype(vlen=v.dtype) is str
-    if getattr(ds, "decode_vlen_strings", True):
-        assert v[0] == _vlen_string
-    else:
-        assert v[0] == _vlen_string.encode("utf_8")
+    if format == "NETCDF4":
+        assert set(ds.groups) == {"subgroup"}
 
-    v = ds["/subgroup/subvar"]
-    assert v is ds["subgroup"]["subvar"]
-    assert v is ds["subgroup/subvar"]
-    assert v is ds["subgroup"]["/subgroup/subvar"]
-    assert v.name == "/subgroup/subvar"
-    assert ds["subgroup"].name == "/subgroup"
-    assert ds["subgroup"].parent is ds
-    assert array_equal(v, np.arange(4.0))
-    assert v.dtype == "int32"
-    assert v.ndim == 1
-    assert v.dimensions == ("x",)
-    assert list(v.attrs) == []
+        v = ds["var_len_str"]
+        assert h5py.check_dtype(vlen=v.dtype) is str
+        if getattr(ds, "decode_vlen_strings", True):
+            assert v[0] == _vlen_string
+        else:
+            assert v[0] == _vlen_string.encode("utf_8")
 
-    assert ds["/subgroup/y_var"].shape == (10,)
-    assert ds["/subgroup"].dimensions["y"].size == 10
+        v = ds["/subgroup/subvar"]
+        assert v is ds["subgroup"]["subvar"]
+        assert v is ds["subgroup/subvar"]
+        assert v is ds["subgroup"]["/subgroup/subvar"]
+        assert v.name == "/subgroup/subvar"
+        assert ds["subgroup"].name == "/subgroup"
+        assert ds["subgroup"].parent is ds
+        assert array_equal(v, np.arange(4.0))
+        assert v.dtype == "int32"
+        assert v.ndim == 1
+        assert v.dimensions == ("x",)
+        assert list(v.attrs) == []
 
-    enum_dict = dict(one=1, two=2, three=3, missing=255)
-    enum_type = ds.enumtypes["enum_t"]
-    assert enum_type.enum_dict == enum_dict
-    v = ds.variables["enum_var"]
-    assert array_equal(v, np.ma.masked_equal([1, 2, 3, 255], 255))
+        assert ds["/subgroup/y_var"].shape == (10,)
+        assert ds["/subgroup"].dimensions["y"].size == 10
+
+        enum_dict = dict(one=1, two=2, three=3, missing=255)
+        enum_type = ds.enumtypes["enum_t"]
+        assert enum_type.enum_dict == enum_dict
+        v = ds.variables["enum_var"]
+        assert array_equal(v, np.ma.masked_equal([1, 2, 3, 255], 255))
 
     ds.close()
 
 
-def roundtrip_legacy_netcdf(tmp_netcdf, read_module, write_module):
-    write_legacy_netcdf(tmp_netcdf, write_module)
+def roundtrip_legacy_netcdf(tmp_netcdf, read_module, write_module, format="NETCDF4"):
+    write_legacy_netcdf(tmp_netcdf, write_module, format)
     read_legacy_netcdf(tmp_netcdf, read_module, write_module)
 
 
@@ -525,13 +609,13 @@ def test_write_h5netcdf_read_legacyapi(tmp_local_netcdf):
     read_legacy_netcdf(tmp_local_netcdf, legacyapi, h5netcdf)
 
 
-def test_write_h5netcdf_read_netCDF4(tmp_local_netcdf):
-    write_h5netcdf(tmp_local_netcdf)
+def test_write_h5netcdf_read_netCDF4(tmp_local_netcdf, format):
+    write_h5netcdf(tmp_local_netcdf, **format)
     read_legacy_netcdf(tmp_local_netcdf, netCDF4, h5netcdf)
 
 
-def test_roundtrip_h5netcdf(tmp_local_or_remote_netcdf, decode_vlen_strings):
-    write_h5netcdf(tmp_local_or_remote_netcdf)
+def test_roundtrip_h5netcdf(tmp_local_or_remote_netcdf, decode_vlen_strings, format):
+    write_h5netcdf(tmp_local_or_remote_netcdf, **format)
     read_h5netcdf(tmp_local_or_remote_netcdf, h5netcdf, decode_vlen_strings)
 
 
@@ -540,8 +624,8 @@ def test_write_compression_as_zlib(tmp_local_netcdf):
     read_legacy_netcdf(tmp_local_netcdf, netCDF4, h5netcdf)
 
 
-def test_write_netCDF4_read_h5netcdf(tmp_local_netcdf, decode_vlen_strings):
-    write_legacy_netcdf(tmp_local_netcdf, netCDF4)
+def test_write_netCDF4_read_h5netcdf(tmp_local_netcdf, decode_vlen_strings, format):
+    write_legacy_netcdf(tmp_local_netcdf, netCDF4, **format)
     read_h5netcdf(tmp_local_netcdf, netCDF4, decode_vlen_strings)
 
 
@@ -2838,3 +2922,12 @@ def test_raise_on_closed_file(tmp_local_netcdf):
         match=f"I/O operation on <Closed h5netcdf.File>: '{tmp_local_netcdf}'",
     ):
         print(v[:])
+
+def test_dump_netcdf4_vs_h5netcdf(tmp_local_netcdf):
+    write_legacy_netcdf(tmp_local_netcdf, netCDF4, format="NETCDF4_CLASSIC")
+    expected = h5dump(tmp_local_netcdf)
+
+    write_legacy_netcdf(tmp_local_netcdf, legacyapi, format="NETCDF4_CLASSIC")
+    actual = h5dump(tmp_local_netcdf)
+
+    assert actual == expected

--- a/h5netcdf/tests/test_h5netcdf.py
+++ b/h5netcdf/tests/test_h5netcdf.py
@@ -92,16 +92,17 @@ def get_hdf5_module(resource):
 def h5dump(fn: str):
     """Call h5dump on an h5netcdf file."""
     import subprocess
+    import re
 
     out = subprocess.run(
-        ["h5dump", "-A", "-B", fn], check=False, capture_output=True
+        ["h5dump", "-A", fn], check=False, capture_output=True
     ).stdout.decode()
 
-    # Strip first and last line
-    # HDF5 "file" {
-    # ...
-    # }
-    return "\n".join(out.splitlines()[1:-1])
+    # Strip non-deterministic components
+    out = re.sub(r'DATASET [0-9]+ "', 'DATASET XXXX "', out)
+
+    return out
+
 
     #
     # @requires_netCDF4

--- a/h5netcdf/utils.py
+++ b/h5netcdf/utils.py
@@ -1,5 +1,6 @@
 from collections.abc import Mapping
-
+import numpy as np
+import h5py
 
 class CompatibilityError(Exception):
     """Raised when using features that are not part of the NetCDF4 API."""
@@ -28,3 +29,18 @@ class Frozen(Mapping):
 
     def __repr__(self):
         return f"{type(self).__name__}({self._mapping!r})"
+
+
+def write_classic_string_attr(gid, name, value):
+    """Write a string attribute to an HDF5 object with control over the strpad."""
+    # Convert to bytes
+    if isinstance(value, str):
+        value = value.encode("utf-8")
+
+    tid = h5py.h5t.C_S1.copy()
+    tid.set_size(len(value))
+    tid.set_strpad(h5py.h5t.STR_NULLTERM)
+    sid = h5py.h5s.create(h5py.h5s.SCALAR)
+    value = np.array(np.bytes_(value))
+    aid = h5py.h5a.create(gid, name.encode(), tid, sid)
+    aid.write(value, mtype=aid.get_type())

--- a/h5netcdf/utils.py
+++ b/h5netcdf/utils.py
@@ -42,5 +42,7 @@ def write_classic_string_attr(gid, name, value):
     tid.set_strpad(h5py.h5t.STR_NULLTERM)
     sid = h5py.h5s.create(h5py.h5s.SCALAR)
     value = np.array(np.bytes_(value))
+    if h5py.h5a.exists(gid, name.encode()):
+        h5py.h5a.delete(gid, name.encode())
     aid = h5py.h5a.create(gid, name.encode(), tid, sid)
     aid.write(value, mtype=aid.get_type())

--- a/h5netcdf/utils.py
+++ b/h5netcdf/utils.py
@@ -1,6 +1,10 @@
 from collections.abc import Mapping
 
 
+class CompatibilityError(Exception):
+    """Raised when using features that are not part of the NetCDF4 API."""
+
+
 class Frozen(Mapping):
     """Wrapper around an object implementing the mapping interface to make it
     immutable. If you really want to modify the mapping, the mutable version is


### PR DESCRIPTION
<!-- Feel free to remove check-list items which aren't relevant to your changes -->

- [x] Closes Issue #280 
- [x] Tests added
- [x] Changes are documented in `CHANGELOG.rst`

This PR adds partial support for the `NETCDF4_CLASSIC` format. 
- Add a `format` argument to `File`;
- Add a global attribute (`_nc3_strict=1`)  when format is `NETCDF4_CLASSIC`;
- Make sure attributes are 1D arrays with one item; 
- Raise an error when numerical data formats are not supported by the CLASSIC format; 
- Raise an error when data are stored to a group; 
- Raise an error when dataset includes more than one unlimited dimensions; 
- Low-level tweak of the padding of string attributes to match `netCDF4`; 

Variables are not cast to supported CLASSIC dtypes. This should be done upstream, e.g. from xarray (see https://github.com/pydata/xarray/pull/10686). Only the low-level bit fiddling is done here. 

There are most probably non CLASSIC cases that are not catched by the checks added here. 

The internal HDF5 representation of the test dataset generated with this PR is close to the netCDF4 generated one, but not identical. See the diff below. 

<details><summary>Diff of h5dump</summary>

 ```diff
   HDF5 "/tmp/pytest-of-david/pytest-274/test_dump_netcdf4_vs_h5netcdf0/testfile.nc" {
    GROUP "/" {
       ATTRIBUTE "_NCProperties" {
          DATATYPE  H5T_STRING {
  -          STRSIZE 34;
  ?                  ^
  +          STRSIZE 74;
  ?                  ^
  -          STRPAD H5T_STR_NULLTERM;
  ?                             ^^^^
  +          STRPAD H5T_STR_NULLPAD;
  ?                             ^^^
             CSET H5T_CSET_ASCII;
             CTYPE H5T_C_S1;
          }
          DATASPACE  SCALAR
          DATA {
  -       (0): "version=2,netcdf=4.9.2,hdf5=1.14.3"
  +       (0): "version=2,h5netcdf=1.7.0.dev4+ge7142b6dd.d20250909,hdf5=1.14.3,h5py=3.11.0"
          }
       }
       ATTRIBUTE "_nc3_strict" {
          DATATYPE  H5T_STD_I32LE
          DATASPACE  SCALAR
          DATA {
          (0): 1
          }
       }
       ATTRIBUTE "global" {
          DATATYPE  H5T_STD_I32LE
          DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
          DATA {
          (0): 42
          }
       }
       ATTRIBUTE "other_attr" {
          DATATYPE  H5T_STRING {
             STRSIZE 3;
             STRPAD H5T_STR_NULLTERM;
             CSET H5T_CSET_ASCII;
             CTYPE H5T_C_S1;
          }
          DATASPACE  SCALAR
          DATA {
          (0): "yes"
          }
       }
       DATASET "_nc4_non_coord_mismatched_dim" {
          DATATYPE  H5T_STD_I32LE
          DATASPACE  SCALAR
       }
       DATASET "foo" {
          DATATYPE  H5T_IEEE_F64LE
          DATASPACE  SIMPLE { ( 4, 5 ) / ( 4, 5 ) }
          ATTRIBUTE "DIMENSION_LIST" {
             DATATYPE  H5T_VLEN { H5T_REFERENCE { H5T_STD_REF_OBJECT } }
             DATASPACE  SIMPLE { ( 2 ) / ( 2 ) }
             DATA {
             (0): (DATASET XXXX "/x"), (DATASET XXXX "/y")
             }
          }
          ATTRIBUTE "_Netcdf4Coordinates" {
             DATATYPE  H5T_STD_I32LE
             DATASPACE  SIMPLE { ( 2 ) / ( 2 ) }
             DATA {
             (0): 0, 1
             }
          }
          ATTRIBUTE "_Netcdf4Dimid" {
             DATATYPE  H5T_STD_I32LE
             DATASPACE  SCALAR
             DATA {
             (0): 0
             }
          }
          ATTRIBUTE "units" {
             DATATYPE  H5T_STRING {
                STRSIZE 6;
                STRPAD H5T_STR_NULLTERM;
                CSET H5T_CSET_ASCII;
                CTYPE H5T_C_S1;
             }
             DATASPACE  SCALAR
             DATA {
             (0): "meters"
             }
          }
       }
       DATASET "foo_unlimited" {
          DATATYPE  H5T_IEEE_F64LE
  -       DATASPACE  SIMPLE { ( 4, 1 ) / ( 4, H5S_UNLIMITED ) }
  ?                                ^
  +       DATASPACE  SIMPLE { ( 4, 0 ) / ( 4, H5S_UNLIMITED ) }
  ?                                ^
          ATTRIBUTE "DIMENSION_LIST" {
             DATATYPE  H5T_VLEN { H5T_REFERENCE { H5T_STD_REF_OBJECT } }
             DATASPACE  SIMPLE { ( 2 ) / ( 2 ) }
             DATA {
             (0): (DATASET XXXX "/x"),
             (1): (DATASET XXXX "/unlimited")
             }
          }
          ATTRIBUTE "_Netcdf4Coordinates" {
             DATATYPE  H5T_STD_I32LE
             DATASPACE  SIMPLE { ( 2 ) / ( 2 ) }
             DATA {
             (0): 0, 4
             }
          }
          ATTRIBUTE "_Netcdf4Dimid" {
             DATATYPE  H5T_STD_I32LE
             DATASPACE  SCALAR
             DATA {
             (0): 0
             }
          }
       }
       DATASET "intscalar" {
          DATATYPE  H5T_STD_I32LE
          DATASPACE  SCALAR
       }
       DATASET "mismatched_dim" {
          DATATYPE  H5T_IEEE_F32BE
          DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
          ATTRIBUTE "CLASS" {
             DATATYPE  H5T_STRING {
                STRSIZE 16;
                STRPAD H5T_STR_NULLTERM;
                CSET H5T_CSET_ASCII;
                CTYPE H5T_C_S1;
             }
             DATASPACE  SCALAR
             DATA {
             (0): "DIMENSION_SCALE"
             }
          }
          ATTRIBUTE "NAME" {
             DATATYPE  H5T_STRING {
                STRSIZE 64;
                STRPAD H5T_STR_NULLTERM;
                CSET H5T_CSET_ASCII;
                CTYPE H5T_C_S1;
             }
             DATASPACE  SCALAR
             DATA {
             (0): "This is a netCDF dimension but not a netCDF variable.         1"
             }
          }
          ATTRIBUTE "_Netcdf4Dimid" {
             DATATYPE  H5T_STD_I32LE
             DATASPACE  SCALAR
             DATA {
             (0): 5
             }
          }
       }
       DATASET "scalar" {
          DATATYPE  H5T_IEEE_F32LE
          DATASPACE  SCALAR
       }
       DATASET "string3" {
          DATATYPE  H5T_IEEE_F32BE
          DATASPACE  SIMPLE { ( 3 ) / ( 3 ) }
          ATTRIBUTE "CLASS" {
             DATATYPE  H5T_STRING {
                STRSIZE 16;
                STRPAD H5T_STR_NULLTERM;
                CSET H5T_CSET_ASCII;
                CTYPE H5T_C_S1;
             }
             DATASPACE  SCALAR
             DATA {
             (0): "DIMENSION_SCALE"
             }
          }
          ATTRIBUTE "NAME" {
             DATATYPE  H5T_STRING {
                STRSIZE 64;
                STRPAD H5T_STR_NULLTERM;
                CSET H5T_CSET_ASCII;
                CTYPE H5T_C_S1;
             }
             DATASPACE  SCALAR
             DATA {
             (0): "This is a netCDF dimension but not a netCDF variable.         3"
             }
          }
          ATTRIBUTE "_Netcdf4Dimid" {
             DATATYPE  H5T_STD_I32LE
             DATASPACE  SCALAR
             DATA {
             (0): 3
             }
          }
       }
       DATASET "unlimited" {
          DATATYPE  H5T_IEEE_F32BE
          DATASPACE  SIMPLE { ( 0 ) / ( H5S_UNLIMITED ) }
          ATTRIBUTE "CLASS" {
             DATATYPE  H5T_STRING {
                STRSIZE 16;
                STRPAD H5T_STR_NULLTERM;
                CSET H5T_CSET_ASCII;
                CTYPE H5T_C_S1;
             }
             DATASPACE  SCALAR
             DATA {
             (0): "DIMENSION_SCALE"
             }
          }
          ATTRIBUTE "NAME" {
             DATATYPE  H5T_STRING {
                STRSIZE 64;
                STRPAD H5T_STR_NULLTERM;
                CSET H5T_CSET_ASCII;
                CTYPE H5T_C_S1;
             }
             DATASPACE  SCALAR
             DATA {
  -          (0): "This is a netCDF dimension but not a netCDF variable.         0"
  ?                                                                              ^
  +          (0): "This is a netCDF dimension but not a netCDF variable.         1"
  ?                                                                              ^
             }
          }
          ATTRIBUTE "REFERENCE_LIST" {
             DATATYPE  H5T_COMPOUND {
                H5T_REFERENCE { H5T_STD_REF_OBJECT } "dataset";
                H5T_STD_U32LE "dimension";
             }
             DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
             DATA {
             (0): {
                   DATASET XXXX "/foo_unlimited",
                   1
                }
             }
          }
          ATTRIBUTE "_Netcdf4Dimid" {
             DATATYPE  H5T_STD_I32LE
             DATASPACE  SCALAR
             DATA {
             (0): 4
             }
          }
       }
       DATASET "x" {
          DATATYPE  H5T_IEEE_F32BE
          DATASPACE  SIMPLE { ( 4 ) / ( 4 ) }
          ATTRIBUTE "CLASS" {
             DATATYPE  H5T_STRING {
                STRSIZE 16;
                STRPAD H5T_STR_NULLTERM;
                CSET H5T_CSET_ASCII;
                CTYPE H5T_C_S1;
             }
             DATASPACE  SCALAR
             DATA {
             (0): "DIMENSION_SCALE"
             }
          }
          ATTRIBUTE "NAME" {
             DATATYPE  H5T_STRING {
                STRSIZE 64;
                STRPAD H5T_STR_NULLTERM;
                CSET H5T_CSET_ASCII;
                CTYPE H5T_C_S1;
             }
             DATASPACE  SCALAR
             DATA {
             (0): "This is a netCDF dimension but not a netCDF variable.         4"
             }
          }
          ATTRIBUTE "REFERENCE_LIST" {
             DATATYPE  H5T_COMPOUND {
                H5T_REFERENCE { H5T_STD_REF_OBJECT } "dataset";
                H5T_STD_U32LE "dimension";
             }
             DATASPACE  SIMPLE { ( 2 ) / ( 2 ) }
             DATA {
             (0): {
                   DATASET XXXX "/foo",
                   0
                },
             (1): {
                   DATASET XXXX "/foo_unlimited",
                   0
                }
             }
          }
          ATTRIBUTE "_Netcdf4Dimid" {
             DATATYPE  H5T_STD_I32LE
             DATASPACE  SCALAR
             DATA {
             (0): 0
             }
          }
       }
       DATASET "y" {
          DATATYPE  H5T_STD_I32LE
          DATASPACE  SIMPLE { ( 5 ) / ( 5 ) }
          ATTRIBUTE "CLASS" {
             DATATYPE  H5T_STRING {
                STRSIZE 16;
                STRPAD H5T_STR_NULLTERM;
                CSET H5T_CSET_ASCII;
                CTYPE H5T_C_S1;
             }
             DATASPACE  SCALAR
             DATA {
             (0): "DIMENSION_SCALE"
             }
          }
          ATTRIBUTE "NAME" {
             DATATYPE  H5T_STRING {
                STRSIZE 2;
                STRPAD H5T_STR_NULLTERM;
                CSET H5T_CSET_ASCII;
                CTYPE H5T_C_S1;
             }
             DATASPACE  SCALAR
             DATA {
             (0): "y"
             }
          }
          ATTRIBUTE "REFERENCE_LIST" {
             DATATYPE  H5T_COMPOUND {
                H5T_REFERENCE { H5T_STD_REF_OBJECT } "dataset";
                H5T_STD_U32LE "dimension";
             }
             DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
             DATA {
             (0): {
                   DATASET XXXX "/foo",
                   1
                }
             }
          }
          ATTRIBUTE "_FillValue" {
             DATATYPE  H5T_STD_I32LE
             DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
             DATA {
             (0): -1
             }
          }
  -       ATTRIBUTE "_Netcdf4Coordinates" {
  -          DATATYPE  H5T_STD_I32LE
  -          DATASPACE  SIMPLE { ( 1 ) / ( 1 ) }
  -          DATA {
  -          (0): 1
  -          }
  -       }
          ATTRIBUTE "_Netcdf4Dimid" {
             DATATYPE  H5T_STD_I32LE
             DATASPACE  SCALAR
             DATA {
             (0): 1
             }
          }
       }
       DATASET "z" {
          DATATYPE  H5T_STRING {
             STRSIZE 1;
  -          STRPAD H5T_STR_NULLTERM;
  ?                             ^^^^
  +          STRPAD H5T_STR_NULLPAD;
  ?                             ^^^
             CSET H5T_CSET_ASCII;
             CTYPE H5T_C_S1;
          }
          DATASPACE  SIMPLE { ( 6, 3 ) / ( 6, 3 ) }
          ATTRIBUTE "CLASS" {
             DATATYPE  H5T_STRING {
                STRSIZE 16;
                STRPAD H5T_STR_NULLTERM;
                CSET H5T_CSET_ASCII;
                CTYPE H5T_C_S1;
             }
             DATASPACE  SCALAR
             DATA {
             (0): "DIMENSION_SCALE"
             }
          }
          ATTRIBUTE "NAME" {
             DATATYPE  H5T_STRING {
                STRSIZE 2;
                STRPAD H5T_STR_NULLTERM;
                CSET H5T_CSET_ASCII;
                CTYPE H5T_C_S1;
             }
             DATASPACE  SCALAR
             DATA {
             (0): "z"
             }
          }
          ATTRIBUTE "_FillValue" {
             DATATYPE  H5T_STRING {
                STRSIZE 1;
                STRPAD H5T_STR_NULLTERM;
                CSET H5T_CSET_ASCII;
                CTYPE H5T_C_S1;
             }
             DATASPACE  SCALAR
             DATA {
             (0): "X"
             }
          }
          ATTRIBUTE "_Netcdf4Coordinates" {
             DATATYPE  H5T_STD_I32LE
             DATASPACE  SIMPLE { ( 2 ) / ( 2 ) }
             DATA {
             (0): 2, 3
             }
          }
          ATTRIBUTE "_Netcdf4Dimid" {
             DATATYPE  H5T_STD_I32LE
             DATASPACE  SCALAR
             DATA {
             (0): 2
             }
          }
       }
    }
    }
```
</details>
