### PR TITLE
fix CI issues with xarray nightly and h5pyd tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,6 +185,7 @@ jobs:
           pip
           pytest
           wheel
+          setuptools=81
           h5py=${{ matrix.h5py-version }}
           netCDF4
           numpy<=${{ matrix.numpy-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -271,6 +271,7 @@ jobs:
           pytest
           pytest-asyncio
           pytest-mypy-plugins
+          pytz
           wheel
           numpy=${{ matrix.numpy-version }}
     - name: Install xarray

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Change Log
 ----------
 
+Development Version (unreleased):
+
+- Fix CI issues with xarray nightly tests (add pytz dependency) and h5pyd tests (pin setuptools=81) (:issue:`312`, :pull:`313`) by `Kai Mühlbauer <https://github.com/kmuehlbauer>`_
+
 Version 1.8.1 (January 23rd, 2026):
 
 - Add numpy to default dependencies, update install section to highlight backend installation, update error message on missing backend (:issue:`310`, :pull:`311`) by `Kai Mühlbauer <https://github.com/kmuehlbauer>`_


### PR DESCRIPTION
- Add pytz to the dependencies in the workflow for xarray nightly tests.
- pin setuptools to 81 as 82 breaks h5pyd/hsds based testing for some reason

<!-- Feel free to remove check-list items which aren't relevant to your changes -->

- [x] Closes Issue #312
- [x] Changes are documented in `CHANGELOG.rst`
